### PR TITLE
FOIA-38: Add a missing dependency.

### DIFF
--- a/docroot/modules/custom/foia_webform/foia_webform.info.yml
+++ b/docroot/modules/custom/foia_webform/foia_webform.info.yml
@@ -3,3 +3,5 @@ type: module
 description: Provides hooks and handlers for Webforms.
 package: Custom
 core: 8.x
+dependencies:
+  - webform:webform


### PR DESCRIPTION
Without this change, 'drush config-import' tries to enable foia_webform
before webform. This leads to an error because of a missing service.