### PR TITLE
FOIA-000: Setting sanitize to false to avoid blt sync issue.

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -19,6 +19,7 @@ drush:
     local: self
     ci: self
   default_alias: '${drush.aliases.local}'
+  sanitize: false
 modules:
   local:
     enable: [dblog, devel, seckit, views_ui]


### PR DESCRIPTION
When running `blt sync` to pull from UAT, I'm seeing the following error when it tries to sanitize users:
```
In Statement.php line 59:

  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'drupal.taxonomy_
  term__scheduled_transition_date' doesn't exist
```

This avoids that issue by setting the sanitize option to false. It's a hack to unblock us for now. We will need a longer term solution to the root issue at some point in the future.