### PR TITLE
FOIA-000: Remove ACSF from uninstall list since we're not using it.

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -23,7 +23,7 @@ drush:
 modules:
   local:
     enable: [dblog, devel, seckit, views_ui]
-    uninstall: [acsf, acquia_connector, shield]
+    uninstall: [acquia_connector, shield]
   ci:
     enable: {  }
     uninstall: [acquia_connector, shield]


### PR DESCRIPTION
It's unclear why ACSF is in the uninstall list since we don't use it. Looking at `git blame`, it's been there forever. I'm seeing it result in intermittent failures when running a `blt sync` though. Taking it out.