### PR TITLE
FOIA-50: Installs and enables view_unpublished module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
+        "php": ">=7.2",
         "acquia/blt": "^10.0.0",
         "acquia/drupal-spec-tool": "^2.0.0",
         "acquia/lightning": "^3.0",
@@ -38,10 +39,10 @@
         "drupal/shield": "^1.0.0",
         "drupal/simplesamlphp_auth": "^3.0",
         "drupal/swiftmailer": "^1.0",
+        "drupal/view_unpublished": "^1.0@alpha",
         "drupal/views_data_export": "^1.0",
         "drupal/webform": "^5.2",
-        "drush/drush": "~9.0",
-        "php": ">=7.2"
+        "drush/drush": "~9.0"
     },
     "require-dev": {
         "acquia/blt-require-dev": "^10.0.0-alpha1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb88284efc610653bbca2e713b0ef606",
+    "content-hash": "a561fe0ee0d6200ec935804bb7f4ab20",
     "packages": [
         {
             "name": "acquia/blt",
@@ -9228,6 +9228,65 @@
             }
         },
         {
+            "name": "drupal/view_unpublished",
+            "version": "1.0.0-alpha1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/view_unpublished.git",
+                "reference": "8.x-1.0-alpha1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/view_unpublished-8.x-1.0-alpha1.zip",
+                "reference": "8.x-1.0-alpha1",
+                "shasum": "6c5928295162027cd4da8f45aba6111d11e899f0"
+            },
+            "require": {
+                "drupal/core": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0-alpha1",
+                    "datestamp": "1483493344",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "amaria",
+                    "homepage": "https://www.drupal.org/user/66428"
+                },
+                {
+                    "name": "beeradb",
+                    "homepage": "https://www.drupal.org/user/120651"
+                },
+                {
+                    "name": "elevins",
+                    "homepage": "https://www.drupal.org/user/781882"
+                },
+                {
+                    "name": "entendu",
+                    "homepage": "https://www.drupal.org/user/173461"
+                }
+            ],
+            "description": "Select which roles should be able to see unpublished nodes.",
+            "homepage": "https://www.drupal.org/project/view_unpublished",
+            "support": {
+                "source": "https://git.drupalcode.org/project/view_unpublished"
+            }
+        },
+        {
             "name": "drupal/views_data_export",
             "version": "1.0.0-beta1",
             "source": {
@@ -17106,7 +17165,8 @@
         "drupal/maillog": 20,
         "drupal/password_policy": 15,
         "drupal/roleassign": 15,
-        "drupal/rules": 15
+        "drupal/rules": 15,
+        "drupal/view_unpublished": 15
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/docroot/modules/custom/foia_api/foia_api.install
+++ b/docroot/modules/custom/foia_api/foia_api.install
@@ -5,6 +5,32 @@
  * Update functions for the FOIA API module.
  */
 
+use Drupal\Core\Utility\UpdateException;
+
+/**
+ * Helper function to enable a Drupal module and print the result.
+ *
+ * @param string $module_name
+ *   The name of the module.
+ *
+ * @return string
+ *   Output for Drush to display on console.
+ */
+function foia_api_enable_module($module_name) {
+  if (\Drupal::moduleHandler()->moduleExists($module_name)) {
+    echo $module_name . ": Already enabled.";
+  }
+  else {
+    try {
+      \Drupal::service('module_installer')->install([$module_name]);
+      return $module_name . " installed.\n";
+    }
+    catch (Exception $error) {
+      throw new UpdateException("An error occurred installing " . $module_name . ": " . $error . "\n");
+    }
+  }
+}
+
 /**
  * Set Agency Component Centralized field.
  */
@@ -36,4 +62,11 @@ function foia_api_update_8001() {
 
   }
 
+}
+
+/**
+ * Enable view_unpublished module.
+ */
+function foia_api_update_8002() {
+  foia_api_enable_module('view_unpublished');
 }


### PR DESCRIPTION
- Adds view_unpublished module to composer.json (and composer.lock).
- Adds update hook to foia_api module's install file to enable view_unpublish.
- Adds foia_api_enable_module() function that provides exception handling for module enablement.