### PR TITLE
FOIA-45: Adds Acquia Pipelines config to code base.

### DIFF
--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -1,0 +1,58 @@
+version: 1.1.0
+services:
+  - mysql
+  - php:
+      version: 7.2
+
+variables:
+  global:
+    COMPOSER_BIN: $SOURCE_DIR/vendor/bin
+    BLT_DIR: $SOURCE_DIR/vendor/acquia/blt
+
+events:
+  build:
+    steps:
+        - setup-env:
+            type: script
+            script:
+              - composer validate --no-check-all --ansi
+              - composer install --ansi
+              - source ${BLT_DIR}/scripts/pipelines/setup_env
+              # - nvm install v6.9.1
+              # - npm install --global yarn
+        - validate:
+            type: script
+            script:
+              - source ${BLT_DIR}/scripts/pipelines/validate
+        # Uncomment these lines to test database updates using live content.
+        # - test-updates:
+        #     type: script
+        #     script:
+        #       - blt drupal:sync:default:site
+        - setup-app:
+            type: script
+            script:
+              - source ${BLT_DIR}/scripts/pipelines/setup_app
+        - tests:
+            type: script
+            script:
+              - source ${BLT_DIR}/scripts/pipelines/tests
+        - build-artifact:
+            type: script
+            script:
+              - source ${BLT_DIR}/scripts/pipelines/build_artifact
+  post-deploy:
+    steps:
+      - deploy:
+          script:
+            - pipelines-deploy
+  pr-merged:
+    steps:
+      - deploy:
+          script:
+            - pipelines-deploy
+  pr-closed:
+    steps:
+      - deploy:
+          script:
+            - pipelines-deploy


### PR DESCRIPTION
- adds missing acquia-pipelines.yml (pipelines configuration) file to project root.
- see welcome message currently generated in pipelines `Execute step welcome` for current PRs:
```Pipelines could not find a acquia-pipelines.yaml in your repository's root directory. Here is an example acquia-pipelines.yaml file you could use:```