### PR TITLE
FOIA-44: Treat non-numeric fields as 0 for autocalc.

### DIFF
--- a/docroot/modules/custom/foia_autocalc/js/autocalc-field.js
+++ b/docroot/modules/custom/foia_autocalc/js/autocalc-field.js
@@ -23,6 +23,11 @@
 
     fieldSettings.forEach(function (fieldSetting) {
       $(convertToFieldSelector(fieldSetting) + ' input').each(function() {
+        var selectedValue = 0;
+        if (isNumeric($(this).val())) {
+          selectedValue = Number($(this).val());
+        }
+
         // Get the selector for this field.
         if (fieldSetting.hasOwnProperty('this_entity') && fieldSetting.this_entity) {
           var index = $(this).attr('name').match(/\[(.*?)\]/)[1];
@@ -34,10 +39,10 @@
 
         // Add value to the selector.
         if (totalValues.hasOwnProperty(idSelector)) {
-          totalValues[idSelector] += Number($(this).val());
+          totalValues[idSelector] += selectedValue;
         }
         else {
-          totalValues[idSelector] = Number($(this).val());
+          totalValues[idSelector] = selectedValue;
         }
       });
     });
@@ -59,6 +64,10 @@
       selector += ' ' + convertToFieldSelector(fieldSetting.subfield);
     }
     return selector;
+  }
+
+  function isNumeric(n) {
+    return !isNaN(parseFloat(n)) && isFinite(n);
   }
 
 })(jQuery, drupalSettings, Drupal);


### PR DESCRIPTION
In particular, this allows "n/a" to be used on XII.A. `field_back_app_end_yr` and still auto-calculate `overall_xiia_back_app_end_yr` by treating that value as 0, instead of displaying `NaN`.