### PR TITLE
FOIA-30: Change betweenminmaxcomp validation method to ≥ min and ≤ max.

### DIFF
--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -76,7 +76,7 @@
         }
         var min = Math.min.apply(null, valuesArray);
         var max = Math.max.apply(null, valuesArray);
-        return this.optional(element) || (value > min) && (value < max);
+        return this.optional(element) || (value >= min) && (value <= max);
       }, "Must be between the smallest and largest values.");
 
       // equalToLowestComp


### PR DESCRIPTION
I confirmed this expectation with Karen and Bobby on a call today. The rationale is that if min and max values are the same number, it should still pass validation.