### PR TITLE
FOIA-6: Import data from Section IV of the XML report.

### DIFF
--- a/config/default/migrate_plus.migration.foia_agency_report.yml
+++ b/config/default/migrate_plus.migration.foia_agency_report.yml
@@ -35,6 +35,14 @@ source:
       label: 'Standard abbreviation of the agency submitting the report'
       selector: '/iepd:FoiaAnnualReport/nc:Organization/nc:OrganizationAbbreviationText'
     -
+      name: field_statute_iv
+      label: Statute
+      selector: 'foia:Exemption3StatuteSection/foia:ReliedUponStatute/@s:id'
+    -
+      name: field_footnotes_iv
+      label: 'IV Footnotes'
+      selector: 'foia:Exemption3StatuteSection/foia:FootnoteText'
+    -
       name: component_va
       label: 'Internal index of the agency component'
       selector: 'foia:ProcessedRequestSection/foia:ProcessingStatistics/@s:id'
@@ -1182,6 +1190,36 @@ process:
   revision_log:
     plugin: default_value
     default_value: 'Import from NIEM-XML data'
+  field_statute_iv:
+    -
+      plugin: foia_array_pad
+      source: field_statute_iv
+      prefix:
+        - report_year
+        - agency
+    -
+      plugin: sub_process
+      process:
+        combined:
+          plugin: migration_lookup
+          source:
+            - '0'
+            - '1'
+            - '2'
+          migration:
+            - foia_iv_statute
+          no_stub: true
+        target_id:
+          plugin: extract
+          source: '@combined'
+          index:
+            - '0'
+        target_revision_id:
+          plugin: extract
+          source: '@combined'
+          index:
+            - '1'
+  field_footnotes_iv: field_footnotes_iv
   field_foia_requests_va:
     -
       plugin: foia_array_pad
@@ -2242,6 +2280,7 @@ destination:
   plugin: 'entity:node'
 migration_dependencies:
   required:
+    - foia_iv_statute
     - foia_va_requests
     - foia_vb1_requests
     - foia_vb3_requests

--- a/config/default/migrate_plus.migration.foia_iv_details.yml
+++ b/config/default/migrate_plus.migration.foia_iv_details.yml
@@ -1,0 +1,72 @@
+uuid: e7a0a669-eb03-4c7d-8769-44eee788cb9e
+langcode: en
+status: true
+dependencies: {  }
+id: foia_iv_details
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: foia_component_data_import
+label: 'Import statute_agency_details paragraphs from NIEM-XML data.'
+source:
+  item_selector: '/iepd:FoiaAnnualReport/foia:Exemption3StatuteSection/foia:ReliedUponStatuteOrganizationAssociation[nc:OrganizationReference/@s:ref!="ORG0"]'
+  fields:
+    -
+      name: report_year
+      label: 'Fiscal year for the current report'
+      selector: '/iepd:FoiaAnnualReport/foia:DocumentFiscalYearDate'
+    -
+      name: agency
+      label: 'Standard abbreviation of the agency submitting the report'
+      selector: '/iepd:FoiaAnnualReport/nc:Organization/nc:OrganizationAbbreviationText'
+    -
+      name: component
+      label: 'Internal index of the agency component'
+      selector: 'nc:OrganizationReference/@s:ref'
+    -
+      name: statute
+      label: 'Internal index of the statute being cited'
+      selector: 'foia:ComponentDataReference/@s:ref'
+    -
+      name: field_num_relied_by_agency_comp
+      label: 'Number of times the statute is used'
+      selector: 'foia:ReliedUponStatuteQuantity'
+  ids:
+    report_year:
+      type: integer
+    agency:
+      type: string
+    statute:
+      type: string
+    component:
+      type: string
+process:
+  type:
+    plugin: default_value
+    default_value: statute_agency_details
+  langcode:
+    plugin: default_value
+    default_value: en
+  status:
+    plugin: default_value
+    default_value: true
+  field_agency_component:
+    -
+      plugin: migration_lookup
+      source:
+        - report_year
+        - agency
+        - component
+      migration:
+        - component
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Cannot find an Agency Component node with the given abbreviation.'
+  field_num_relied_by_agency_comp: field_num_relied_by_agency_comp
+destination: null
+migration_dependencies:
+  required:
+    - component

--- a/config/default/migrate_plus.migration.foia_iv_statute.yml
+++ b/config/default/migrate_plus.migration.foia_iv_statute.yml
@@ -1,0 +1,127 @@
+uuid: 1a4f73d3-bf98-47b2-8fc2-5200e6921d96
+langcode: en
+status: true
+dependencies: {  }
+id: foia_iv_statute
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: foia_component_data_import
+label: 'Import statute paragraphs from NIEM-XML data.'
+source:
+  item_selector: '/iepd:FoiaAnnualReport/foia:Exemption3StatuteSection/foia:ReliedUponStatute'
+  fields:
+    -
+      name: report_year
+      label: 'Fiscal year for the current report'
+      selector: '/iepd:FoiaAnnualReport/foia:DocumentFiscalYearDate'
+    -
+      name: agency
+      label: 'Standard abbreviation of the agency submitting the report'
+      selector: '/iepd:FoiaAnnualReport/nc:Organization/nc:OrganizationAbbreviationText'
+    -
+      name: statute
+      label: 'Internal index of the statute being cited'
+      selector: '@s:id'
+    -
+      name: field_num_relied_by_agency_comp
+      label: 'Number of times the statute is used'
+      selector: 'foia:ReliedUponStatuteQuantity'
+    -
+      name: field_agency_component_inf
+      label: 'Agency/Component Information'
+      selector: '../foia:ReliedUponStatuteOrganizationAssociation[nc:OrganizationReference/@s:ref!="ORG0"]/nc:OrganizationReference/@s:ref'
+    -
+      name: field_agency_component_inf_filter
+      label: 'Filter for Agency/Component Information'
+      selector: '../foia:ReliedUponStatuteOrganizationAssociation[nc:OrganizationReference/@s:ref!="ORG0"]/foia:ComponentDataReference/@s:ref'
+    -
+      name: field_case_citation
+      label: 'Case citation'
+      selector: 'nc:Case/nc:CaseTitleText'
+    -
+      name: field_statute
+      label: Statute
+      selector: 'j:StatuteDescriptionText'
+    -
+      name: field_total_num_relied_by_agency
+      label: 'Total Number of Times Relied upon by Agency Overall'
+      selector: '../foia:ReliedUponStatuteOrganizationAssociation[nc:OrganizationReference/@s:ref="ORG0"]/foia:ReliedUponStatuteQuantity'
+    -
+      name: field_total_num_relied_by_agency_filter
+      label: 'Filter for Total Number of Times Relied upon by Agency Overall'
+      selector: '../foia:ReliedUponStatuteOrganizationAssociation[nc:OrganizationReference/@s:ref="ORG0"]/foia:ComponentDataReference/@s:ref'
+    -
+      name: field_type_of_info_withheld
+      label: 'Type of Information Withheld'
+      selector: 'foia:ReliedUponStatuteInformationWithheldText'
+  ids:
+    report_year:
+      type: integer
+    agency:
+      type: string
+    statute:
+      type: string
+process:
+  type:
+    plugin: default_value
+    default_value: statute
+  langcode:
+    plugin: default_value
+    default_value: en
+  status:
+    plugin: default_value
+    default_value: true
+  field_agency_component_inf:
+    -
+      plugin: foia_filter_values
+      source:
+        - field_agency_component_inf
+        - field_agency_component_inf_filter
+        - statute
+    -
+      plugin: foia_array_pad
+      prefix:
+        - report_year
+        - agency
+        - statute
+    -
+      plugin: sub_process
+      process:
+        combined:
+          plugin: migration_lookup
+          source:
+            - '0'
+            - '1'
+            - '2'
+            - '3'
+          migration:
+            - foia_iv_details
+          no_stub: true
+        target_id:
+          plugin: extract
+          source: '@combined'
+          index:
+            - '0'
+        target_revision_id:
+          plugin: extract
+          source: '@combined'
+          index:
+            - '1'
+  field_case_citation: field_case_citation
+  field_statute: field_statute
+  field_total_num_relied_by_agency:
+    -
+      plugin: foia_filter_values
+      source:
+        - field_total_num_relied_by_agency
+        - field_total_num_relied_by_agency_filter
+        - statute
+    -
+      plugin: array_pop
+  field_type_of_info_withheld: field_type_of_info_withheld
+destination: null
+migration_dependencies:
+  required:
+    - foia_iv_details

--- a/docroot/modules/custom/foia_upload_xml/config/install/migrate_plus.migration.foia_agency_report.yml
+++ b/docroot/modules/custom/foia_upload_xml/config/install/migrate_plus.migration.foia_agency_report.yml
@@ -29,6 +29,15 @@ source:
       name: agency
       label: 'Standard abbreviation of the agency submitting the report'
       selector: '/iepd:FoiaAnnualReport/nc:Organization/nc:OrganizationAbbreviationText'
+  # Section IV
+    -
+      name: field_statute_iv
+      label: 'Statute'
+      selector: 'foia:Exemption3StatuteSection/foia:ReliedUponStatute/@s:id'
+    -
+      name: field_footnotes_iv
+      label: 'IV Footnotes'
+      selector: 'foia:Exemption3StatuteSection/foia:FootnoteText'
   # Section V.A
   # @todo Find something more reliable than using @s:id="PS0" for the overall
   # numbers.
@@ -1252,6 +1261,37 @@ process:
   revision_log:
     plugin: default_value
     default_value: 'Import from NIEM-XML data'
+  # Section IV
+  field_statute_iv:
+    -
+      plugin: foia_array_pad
+      source: field_statute_iv
+      prefix:
+        - report_year
+        - agency
+    -
+      plugin: sub_process
+      process:
+        combined:
+          plugin: migration_lookup
+          source:
+            - '0'
+            - '1'
+            - '2'
+          migration:
+            - foia_iv_statute
+          no_stub: true
+        target_id:
+          plugin: extract
+          source: '@combined'
+          index:
+            - '0'
+        target_revision_id:
+          plugin: extract
+          source: '@combined'
+          index:
+            - '1'
+  field_footnotes_iv: field_footnotes_iv
   # Section V.A
   # FOIA requests -- received, processed and pending FOIA requests
   field_foia_requests_va:
@@ -2369,6 +2409,7 @@ destination:
   plugin: entity:node
 migration_dependencies:
   required:
+    - foia_iv_statute
     - foia_va_requests
     - foia_vb1_requests
     - foia_vb3_requests

--- a/docroot/modules/custom/foia_upload_xml/config/install/migrate_plus.migration.foia_iv_details.yml
+++ b/docroot/modules/custom/foia_upload_xml/config/install/migrate_plus.migration.foia_iv_details.yml
@@ -1,0 +1,63 @@
+id: foia_iv_details
+label: 'Import statute_agency_details paragraphs from NIEM-XML data.'
+migration_group: foia_component_data_import
+source:
+  item_selector: '/iepd:FoiaAnnualReport/foia:Exemption3StatuteSection/foia:ReliedUponStatuteOrganizationAssociation[nc:OrganizationReference/@s:ref!="ORG0"]'
+  fields:
+    -
+      name: report_year
+      label: 'Fiscal year for the current report'
+      selector: '/iepd:FoiaAnnualReport/foia:DocumentFiscalYearDate'
+    -
+      name: agency
+      label: 'Standard abbreviation of the agency submitting the report'
+      selector: '/iepd:FoiaAnnualReport/nc:Organization/nc:OrganizationAbbreviationText'
+    -
+      name: component
+      label: 'Internal index of the agency component'
+      selector: 'nc:OrganizationReference/@s:ref'
+    -
+      name: statute
+      label: 'Internal index of the statute being cited'
+      selector: 'foia:ComponentDataReference/@s:ref'
+    -
+      name: field_num_relied_by_agency_comp
+      label: 'Number of times the statute is used'
+      selector: 'foia:ReliedUponStatuteQuantity'
+  ids:
+    report_year:
+      type: integer
+    agency:
+      type: string
+    statute:
+      type: string
+    component:
+      type: string
+process:
+  type:
+    plugin: default_value
+    default_value: statute_agency_details
+  langcode:
+    plugin: default_value
+    default_value: en
+  status:
+    plugin: default_value
+    default_value: true
+  field_agency_component:
+    -
+      plugin: migration_lookup
+      source:
+        - report_year
+        - agency
+        - component
+      migration:
+        - component
+      no_stub: true
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Cannot find an Agency Component node with the given abbreviation.'
+  field_num_relied_by_agency_comp: field_num_relied_by_agency_comp
+migration_dependencies:
+  required:
+    - component

--- a/docroot/modules/custom/foia_upload_xml/config/install/migrate_plus.migration.foia_iv_statute.yml
+++ b/docroot/modules/custom/foia_upload_xml/config/install/migrate_plus.migration.foia_iv_statute.yml
@@ -1,0 +1,118 @@
+id: foia_iv_statute
+label: 'Import statute paragraphs from NIEM-XML data.'
+migration_group: foia_component_data_import
+source:
+  item_selector: '/iepd:FoiaAnnualReport/foia:Exemption3StatuteSection/foia:ReliedUponStatute'
+  fields:
+    -
+      name: report_year
+      label: 'Fiscal year for the current report'
+      selector: '/iepd:FoiaAnnualReport/foia:DocumentFiscalYearDate'
+    -
+      name: agency
+      label: 'Standard abbreviation of the agency submitting the report'
+      selector: '/iepd:FoiaAnnualReport/nc:Organization/nc:OrganizationAbbreviationText'
+    -
+      name: statute
+      label: 'Internal index of the statute being cited'
+      selector: '@s:id'
+    -
+      name: field_num_relied_by_agency_comp
+      label: 'Number of times the statute is used'
+      selector: 'foia:ReliedUponStatuteQuantity'
+    -
+      name: field_agency_component_inf
+      label: 'Agency/Component Information'
+      selector: '../foia:ReliedUponStatuteOrganizationAssociation[nc:OrganizationReference/@s:ref!="ORG0"]/nc:OrganizationReference/@s:ref'
+    -
+      name: field_agency_component_inf_filter
+      label: 'Filter for Agency/Component Information'
+      selector: '../foia:ReliedUponStatuteOrganizationAssociation[nc:OrganizationReference/@s:ref!="ORG0"]/foia:ComponentDataReference/@s:ref'
+    -
+      name: field_case_citation
+      label: 'Case citation'
+      selector: 'nc:Case/nc:CaseTitleText'
+    -
+      name: field_statute
+      label: 'Statute'
+      selector: 'j:StatuteDescriptionText'
+    -
+      name: field_total_num_relied_by_agency
+      label: 'Total Number of Times Relied upon by Agency Overall'
+      selector: '../foia:ReliedUponStatuteOrganizationAssociation[nc:OrganizationReference/@s:ref="ORG0"]/foia:ReliedUponStatuteQuantity'
+    -
+      name: field_total_num_relied_by_agency_filter
+      label: 'Filter for Total Number of Times Relied upon by Agency Overall'
+      selector: '../foia:ReliedUponStatuteOrganizationAssociation[nc:OrganizationReference/@s:ref="ORG0"]/foia:ComponentDataReference/@s:ref'
+    -
+      name: field_type_of_info_withheld
+      label: 'Type of Information Withheld'
+      selector: 'foia:ReliedUponStatuteInformationWithheldText'
+  ids:
+    report_year:
+      type: integer
+    agency:
+      type: string
+    statute:
+      type: string
+process:
+  type:
+    plugin: default_value
+    default_value: statute
+  langcode:
+    plugin: default_value
+    default_value: en
+  status:
+    plugin: default_value
+    default_value: true
+  field_agency_component_inf:
+    -
+      plugin: foia_filter_values
+      source:
+        - field_agency_component_inf
+        - field_agency_component_inf_filter
+        - statute
+    -
+      plugin: foia_array_pad
+      prefix:
+        - report_year
+        - agency
+        - statute
+    -
+      plugin: sub_process
+      process:
+        combined:
+          plugin: migration_lookup
+          source:
+            - '0'
+            - '1'
+            - '2'
+            - '3'
+          migration:
+            - foia_iv_details
+          no_stub: true
+        target_id:
+          plugin: extract
+          source: '@combined'
+          index:
+            - '0'
+        target_revision_id:
+          plugin: extract
+          source: '@combined'
+          index:
+            - '1'
+  field_case_citation: field_case_citation
+  field_statute: field_statute
+  field_total_num_relied_by_agency:
+    -
+      plugin: foia_filter_values
+      source:
+        - field_total_num_relied_by_agency
+        - field_total_num_relied_by_agency_filter
+        - statute
+    -
+      plugin: array_pop
+  field_type_of_info_withheld: field_type_of_info_withheld
+migration_dependencies:
+  required:
+    - foia_iv_details

--- a/docroot/modules/custom/foia_upload_xml/src/Plugin/migrate/process/FilterValues.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Plugin/migrate/process/FilterValues.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\foia_upload_xml\Plugin\migrate\process;
+
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Row;
+
+/**
+ * Combine each element of an array with a fixed set of values.
+ *
+ * Example:
+ *
+ * @code
+ * process:
+ *   values:
+ *     plugin: foia_filter_values
+ *     source:
+ *       - key_1
+ *       - key_2
+ *       - key_3
+ * @endcode
+ *
+ * The first (source) and second (filter) keys should be arrays of the same
+ * length. Return the source array, selecting those elements for which the
+ * filter array matches the third key (target).
+ *
+ * For example, if the first key is [1, 2, 3, 4], the second is [0, 1, 0, 1],
+ * and the third is 1, then return [2, 4].
+ *
+ * As usual, the keys can be destination keys using the format '@dest_key'.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "foia_filter_values",
+ *   handle_multiples = TRUE
+ * )
+ */
+class FilterValues extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $source = $value[0];
+    $filter = $value[1];
+    $target = $value[2];
+    $result = [];
+    foreach (array_keys($source) as $key) {
+      if ($filter[$key] == $target) {
+        $result[] = $source[$key];
+      }
+    }
+    return $result;
+  }
+
+}


### PR DESCRIPTION
~This is totally untested and incomplete, so do not merge yet.~

Update: ready to roll.

One caveat: there is an unanswered question on FOIA-6. Depending on the answer, we may need to modify this code.

> I notice that `field_case_citation` on the Statute paragraph type is limited to 255 characters, but the sample XML file (USDA 2018) includes this entry:
> ...
> I believe that is 342 characters, 344 bytes. Should we truncate the text during import or should we change the definition of that field?