### PR TITLE
FOIA-30: Remove jQuery Validation debugging code.

### DIFF
--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -1,11 +1,6 @@
 (function ($, drupalSettings, Drupal) {
   Drupal.behaviors.foia_ui_validation = {
     attach: function attach() {
-      jQuery.validator.setDefaults({
-        debug: true,
-        success: "valid"
-      });
-
       /**
        * Custom validation methods
        */

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -1,6 +1,11 @@
 (function ($, drupalSettings, Drupal) {
   Drupal.behaviors.foia_ui_validation = {
     attach: function attach() {
+      jQuery.validator.setDefaults({
+        ignore: ".ignore-validation",
+        onsubmit: false
+      });
+
       /**
        * Custom validation methods
        */


### PR DESCRIPTION
- Allows new annual report nodes to be submitted.
- Now validates fields on inactive vertical tabs.
- Disables validation when saving.