### PR TITLE
FOIA-30: Disables validation alert messages.

### DIFF
--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -117,7 +117,7 @@
           var errors = validator.numberOfInvalids();
           if (errors) {
             var message = errors == 1 ? '1 field is invalid and has been highlighted.' : '' + errors + ' fields are invalid and have been highlighted.';
-            alert(message);
+            // alert(message);
           }
         },
 


### PR DESCRIPTION
The alert messages are a nuisance when displayed more than once. Ultimately, the problem is that the `invalidhandler` is getting invoked more than once, but until that issue is resolved, this is an interim usability improvement.