### PR TITLE
FOIA-90: Rules for XII C

### DIFF
--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -17,15 +17,15 @@
 
       // lessThanEqualToNA
       $.validator.addMethod( "lessThanEqualToNA", function( value, element, param ) {
-        var target = $( param );
+        var target = $( param ).val();
         // Treat N/A like 0.
         if ( String(value).toLowerCase() == "n/a" ) {
-          value = 0;
+          value = Number(0);
         }
         if ( String(target).toLowerCase() == "n/a" ) {
-          target = 0;
+          target = Number(0);
         }
-        return value <= Number(target.val());
+        return value <= Number(target);
     }, "Please enter a lesser value." );
 
        // greaterThanEqualTo
@@ -767,6 +767,82 @@
           }
         });
       });
+
+      // For the next 9 rules, each is comparing the value to the one lower
+      // than it ( i.e., field 10 is less than field 9, field 9 is less than
+      // field 8, etc).
+      // XII.C. CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 10th
+      $( "#edit-field-overall-xiic-num-days-10-0-value").rules( "add", {
+        lessThanEqualToNA: "#edit-field-overall-xiic-num-days-9-0-value",
+        messages: {
+          lessThanEqualToNA: "This should be less than the number of days for \"9th\"."
+        }
+      });
+
+      // XII.C. CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 9th
+      $( "#edit-field-overall-xiic-num-days-9-0-value").rules( "add", {
+        lessThanEqualToNA: "#edit-field-overall-xiic-num-days-8-0-value",
+        messages: {
+          lessThanEqualToNA: "This should be less than the number of days for \"8th\"."
+        }
+      });
+
+      // XII.C. CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 8th
+      $( "#edit-field-overall-xiic-num-days-8-0-value").rules( "add", {
+        lessThanEqualToNA: "#edit-field-overall-xiic-num-days-7-0-value",
+        messages: {
+          lessThanEqualToNA: "This should be less than the number of days for \"7th\"."
+        }
+      });
+
+      // XII.C. CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 7th
+      $( "#edit-field-overall-xiic-num-days-7-0-value").rules( "add", {
+        lessThanEqualToNA: "#edit-field-overall-xiic-num-days-6-0-value",
+        messages: {
+          lessThanEqualToNA: "This should be less than the number of days for \"6th\"."
+        }
+      });
+
+      // XII.C. CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 6th
+      $( "#edit-field-overall-xiic-num-days-6-0-value").rules( "add", {
+        lessThanEqualToNA: "#edit-field-overall-xiic-num-days-5-0-value",
+        messages: {
+          lessThanEqualToNA: "This should be less than the number of days for \"5th\"."
+        }
+      });
+
+      // XII.C. CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 5th
+      $( "#edit-field-overall-xiic-num-days-5-0-value").rules( "add", {
+        lessThanEqualToNA: "#edit-field-overall-xiic-num-days-4-0-value",
+        messages: {
+          lessThanEqualToNA: "This should be less than the number of days for \"4th\"."
+        }
+      });
+
+      // XII.C. CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 4th
+      $( "#edit-field-overall-xiic-num-days-4-0-value").rules( "add", {
+        lessThanEqualToNA: "#edit-field-overall-xiic-num-days-3-0-value",
+        messages: {
+          lessThanEqualToNA: "This should be less than the number of days for \"3d\"."
+        }
+      });
+
+      // XII.C. CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 3d
+      $( "#edit-field-overall-xiic-num-days-3-0-value").rules( "add", {
+        lessThanEqualToNA: "#edit-field-overall-xiic-num-days-2-0-value",
+        messages: {
+          lessThanEqualToNA: "This should be less than the number of days for \"2d\"."
+        }
+      });
+
+      // XII.C. CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 2d
+      $( "#edit-field-overall-xiic-num-days-2-0-value").rules( "add", {
+        lessThanEqualToNA: "#edit-field-overall-xiic-num-days-1-0-value",
+        messages: {
+          lessThanEqualToNA: "This should be less than the number of days for \"Overall\"."
+        }
+      });
+
     }
   };
 


### PR DESCRIPTION
The change to the "lessThanEqualToNA" method, adding the .val() to the param at the top, was a result of testing when two subsequent fields both had "n/a".  It should apply to the other validation fields using this method also.