### PR TITLE
FOIA-96: Changing disabled attribute to readonly.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,8 @@
         "patches": {
             "drupal/core": {
                 "Account for null triggering element when validating managed file elements": "https://www.drupal.org/files/issues/validating_managed-2910320-2.patch",
-                "JSONAPI fix for missing entities": "https://www.drupal.org/files/issues/2019-06-21/drupal--jsonapi--3063326--public-name-for-relatable-fields.patch"
+                "JSONAPI fix for missing entities": "https://www.drupal.org/files/issues/2019-06-21/drupal--jsonapi--3063326--public-name-for-relatable-fields.patch",
+                "FOIA-96: Style read-only inputs as disabled": "./patches/FOIA-96-readonly-inputs.patch"
             },
             "drupal/password_policy": {
                 "Config install issues": "https://www.drupal.org/files/issues/password-policy-config-import-field-error-2771129-49-D8.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1fdaa5fe9f849c7fcbcacadec33f2f9",
+    "content-hash": "0eca321a52f6605a3ad98dabd3cc84a6",
     "packages": [
         {
             "name": "acquia/blt",
@@ -847,7 +847,8 @@
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/fengyuanchen/cropper/zipball/30c58b29ee21010e17e58ebab165fbd84285c685",
-                "reference": "30c58b29ee21010e17e58ebab165fbd84285c685"
+                "reference": "30c58b29ee21010e17e58ebab165fbd84285c685",
+                "shasum": null
             },
             "type": "bower-asset",
             "license": [
@@ -865,7 +866,8 @@
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/enyo/dropzone/zipball/08b9e0a763b54a685404dea523a9c54242fbe1b9",
-                "reference": "08b9e0a763b54a685404dea523a9c54242fbe1b9"
+                "reference": "08b9e0a763b54a685404dea523a9c54242fbe1b9",
+                "shasum": null
             },
             "type": "bower-asset"
         },
@@ -880,7 +882,8 @@
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/jquery/jquery-dist/zipball/15bc73803f76bc53b654b9fdbbbc096f56d7c03d",
-                "reference": "15bc73803f76bc53b654b9fdbbbc096f56d7c03d"
+                "reference": "15bc73803f76bc53b654b9fdbbbc096f56d7c03d",
+                "shasum": null
             },
             "type": "bower-asset",
             "license": [
@@ -898,7 +901,8 @@
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/kenwheeler/slick/zipball/0f40c9d6a02a5c08b5f4dd80fdada3a854a59bee",
-                "reference": "0f40c9d6a02a5c08b5f4dd80fdada3a854a59bee"
+                "reference": "0f40c9d6a02a5c08b5f4dd80fdada3a854a59bee",
+                "shasum": null
             },
             "require": {
                 "bower-asset/jquery": ">=1.7"
@@ -4273,6 +4277,7 @@
                 "patches_applied": {
                     "Account for null triggering element when validating managed file elements": "https://www.drupal.org/files/issues/validating_managed-2910320-2.patch",
                     "JSONAPI fix for missing entities": "https://www.drupal.org/files/issues/2019-06-21/drupal--jsonapi--3063326--public-name-for-relatable-fields.patch",
+                    "FOIA-96: Style read-only inputs as disabled": "./patches/FOIA-96-readonly-inputs.patch",
                     "2869592 - Disabled update module shouldn't produce a status report warning": "https://www.drupal.org/files/issues/2869592-remove-update-warning-7.patch",
                     "2885441 - EntityReferenceAutocompleteWidget should define its size setting as an integer": "https://www.drupal.org/files/issues/2885441-2.patch",
                     "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2019-03-05/2815221-116.patch",
@@ -6214,7 +6219,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.8",
-                    "datestamp": "1560872886",
+                    "datestamp": "1565730484",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7352,7 +7357,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.9",
-                    "datestamp": "1563995941",
+                    "datestamp": "1567099985",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8316,7 +8321,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.8",
-                    "datestamp": "1553618281",
+                    "datestamp": "1565881389",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8767,7 +8772,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.0-alpha4",
-                    "datestamp": "1526654284",
+                    "datestamp": "1566193991",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -10082,7 +10087,7 @@
                 },
                 "drupal": {
                     "version": "8.x-5.3",
-                    "datestamp": "1563460085",
+                    "datestamp": "1566209286",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -12776,7 +12781,9 @@
             "version": "1.19.1",
             "dist": {
                 "type": "tar",
-                "url": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.19.1.tgz"
+                "url": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.19.1.tgz",
+                "reference": null,
+                "shasum": null
             },
             "type": "npm-asset",
             "license": [
@@ -16461,19 +16468,19 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
+                    "role": "Lead Developer",
                     "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "homepage": "http://fabien.potencier.org"
                 },
                 {
                     "name": "Armin Ronacher",
-                    "email": "armin.ronacher@active-4.com",
-                    "role": "Project Founder"
+                    "role": "Project Founder",
+                    "email": "armin.ronacher@active-4.com"
                 },
                 {
                     "name": "Twig Team",
-                    "homepage": "https://twig.symfony.com/contributors",
-                    "role": "Contributors"
+                    "role": "Contributors",
+                    "homepage": "https://twig.symfony.com/contributors"
                 }
             ],
             "description": "Twig, the flexible, fast, and secure template language for PHP",

--- a/docroot/modules/custom/foia_readonly/foia_readonly.module
+++ b/docroot/modules/custom/foia_readonly/foia_readonly.module
@@ -239,7 +239,7 @@ function foia_readonly_disable_node_field(&$form, FormStateInterface $form_state
 
   foreach ($fieldsToDisable as $fieldName) {
     $fullFieldName = 'field_' . $fieldName;
-    $form[$fullFieldName]['widget'][0]['value']['#attributes']['disabled'] = TRUE;
+    $form[$fullFieldName]['widget'][0]['value']['#attributes']['readonly'] = TRUE;
   }
 }
 
@@ -256,7 +256,7 @@ function foia_readonly_disable_paragraph_field(array &$elements, $field_name) {
     if (array_key_exists($delta, $elements)
       && array_key_exists('subform', $elements[$delta])
       && array_key_exists($field_name, $elements[$delta]['subform'])) {
-      $elements[$delta]['subform'][$field_name]['widget'][0]['value']['#attributes']['disabled'] = TRUE;
+      $elements[$delta]['subform'][$field_name]['widget'][0]['value']['#attributes']['readonly'] = TRUE;
     }
   }
 }

--- a/patches/FOIA-96-readonly-inputs.patch
+++ b/patches/FOIA-96-readonly-inputs.patch
@@ -1,0 +1,21 @@
+diff --git a/core/themes/seven/css/components/form.css b/core/themes/seven/css/components/form.css
+index 98e78914e9..638db2c992 100644
+--- a/core/themes/seven/css/components/form.css
++++ b/core/themes/seven/css/components/form.css
+@@ -353,3 +353,16 @@ select {
+ div.filter-options select {
+   padding: 0;
+ }
++
++
++/* Display :read-only elements as if they are disabled */
++input:-moz-read-only,
++input:-moz-read-only:focus { /* For Firefox */
++  background-color: hsla(0,0%,0%,0.08);
++}
++
++input:read-only,
++input:read-only:focus {
++  background-color: hsla(0,0%,0%,0.08);
++}
++


### PR DESCRIPTION
This corrects a failure with my initial FOIA-96 work, which set the fields to disabled rather than readonly.  Unfortunately this change costs us the default styling of disabled fields. 