### PR TITLE
FOIA-148: Fix to abbreviations table.

### DIFF
--- a/docroot/modules/custom/node_to_docx/templates/docx-agency-component-abbrev.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-agency-component-abbrev.html.twig
@@ -21,7 +21,7 @@
  <tr >
   <td nowrap valign=bottom >
   <p class=MsoNormal >
-  {{ content.field_agency_components[0]['#options'].entity.field_agency_comp_abbreviation.value }}
+  {{ content.field_agency_components[key]['#options'].entity.field_agency_comp_abbreviation.value }}
   <o:p></o:p></p>
   </td>
   <td nowrap valign=bottom >


### PR DESCRIPTION
The variable printing out the abbreviation was not being incremented with the loop variable -- good catch by Barrett.