### PR TITLE
FOIA-164: Switch VI.C(4) field to text to allow for <1.

### DIFF
--- a/config/default/core.entity_form_display.node.annual_foia_report_data.default.yml
+++ b/config/default/core.entity_form_display.node.annual_foia_report_data.default.yml
@@ -2930,32 +2930,36 @@ content:
     type: number
     region: content
   field_overall_vic4_avg_num_days:
-    weight: 25
+    weight: 162
     settings:
+      size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: number
+    type: string_textfield
     region: content
   field_overall_vic4_high_num_days:
-    weight: 27
+    weight: 163
     settings:
+      size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: number
+    type: string_textfield
     region: content
   field_overall_vic4_low_num_days:
-    weight: 26
+    weight: 164
     settings:
+      size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: number
+    type: string_textfield
     region: content
   field_overall_vic4_med_num_days:
-    weight: 24
+    weight: 165
     settings:
+      size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: number
+    type: string_textfield
     region: content
   field_overall_vic5_date_1:
     weight: 44

--- a/config/default/core.entity_form_display.paragraph.admin_app_vic4.default.yml
+++ b/config/default/core.entity_form_display.paragraph.admin_app_vic4.default.yml
@@ -23,32 +23,36 @@ content:
     type: erviews_options_select
     region: content
   field_avg_num_days:
-    weight: 2
+    weight: 1
     settings:
+      size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: number
+    type: string_textfield
     region: content
   field_high_num_days:
-    weight: 4
+    weight: 2
     settings:
+      size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: number
+    type: string_textfield
     region: content
   field_low_num_days:
     weight: 3
     settings:
+      size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: number
+    type: string_textfield
     region: content
   field_med_num_days:
-    weight: 1
+    weight: 4
     settings:
+      size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: number
+    type: string_textfield
     region: content
 hidden:
   created: true

--- a/config/default/core.entity_view_display.node.annual_foia_report_data.default.yml
+++ b/config/default/core.entity_view_display.node.annual_foia_report_data.default.yml
@@ -1461,48 +1461,36 @@ content:
     type: number_integer
     region: content
   field_overall_vic4_avg_num_days:
-    weight: 117
+    weight: 327
     label: above
     settings:
-      thousand_separator: ''
-      decimal_separator: .
-      scale: 2
-      prefix_suffix: true
+      link_to_entity: false
     third_party_settings: {  }
-    type: number_decimal
+    type: string
     region: content
   field_overall_vic4_high_num_days:
-    weight: 120
+    weight: 328
     label: above
     settings:
-      thousand_separator: ''
-      decimal_separator: .
-      scale: 2
-      prefix_suffix: true
+      link_to_entity: false
     third_party_settings: {  }
-    type: number_decimal
+    type: string
     region: content
   field_overall_vic4_low_num_days:
-    weight: 119
+    weight: 329
     label: above
     settings:
-      thousand_separator: ''
-      decimal_separator: .
-      scale: 2
-      prefix_suffix: true
+      link_to_entity: false
     third_party_settings: {  }
-    type: number_decimal
+    type: string
     region: content
   field_overall_vic4_med_num_days:
-    weight: 116
+    weight: 330
     label: above
     settings:
-      thousand_separator: ''
-      decimal_separator: .
-      scale: 2
-      prefix_suffix: true
+      link_to_entity: false
     third_party_settings: {  }
-    type: number_decimal
+    type: string
     region: content
   field_overall_vic5_date_1:
     weight: 139

--- a/config/default/core.entity_view_display.paragraph.admin_app_vic4.default.yml
+++ b/config/default/core.entity_view_display.paragraph.admin_app_vic4.default.yml
@@ -23,48 +23,36 @@ content:
     type: entity_reference_label
     region: content
   field_avg_num_days:
-    weight: 2
+    weight: 6
     label: above
     settings:
-      thousand_separator: ''
-      decimal_separator: .
-      scale: 2
-      prefix_suffix: true
+      link_to_entity: false
     third_party_settings: {  }
-    type: number_decimal
+    type: string
     region: content
   field_high_num_days:
-    weight: 4
+    weight: 7
     label: above
     settings:
-      thousand_separator: ''
-      decimal_separator: .
-      scale: 2
-      prefix_suffix: true
+      link_to_entity: false
     third_party_settings: {  }
-    type: number_decimal
+    type: string
     region: content
   field_low_num_days:
-    weight: 3
+    weight: 8
     label: above
     settings:
-      thousand_separator: ''
-      decimal_separator: .
-      scale: 2
-      prefix_suffix: true
+      link_to_entity: false
     third_party_settings: {  }
-    type: number_decimal
+    type: string
     region: content
   field_med_num_days:
-    weight: 1
+    weight: 9
     label: above
     settings:
-      thousand_separator: ''
-      decimal_separator: .
-      scale: 2
-      prefix_suffix: true
+      link_to_entity: false
     third_party_settings: {  }
-    type: number_decimal
+    type: string
     region: content
 hidden:
   search_api_excerpt: true

--- a/config/default/field.field.node.annual_foia_report_data.field_overall_vic4_avg_num_days.yml
+++ b/config/default/field.field.node.annual_foia_report_data.field_overall_vic4_avg_num_days.yml
@@ -1,10 +1,17 @@
-uuid: c6a6a318-ea1d-495f-b308-5530b6d2cc0d
+uuid: 9274e58c-3960-429d-aecc-ce3cefae8eff
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_overall_vic4_avg_num_days
     - node.type.annual_foia_report_data
+  module:
+    - foia_autocalc
+third_party_settings:
+  foia_autocalc:
+    autocalc_settings:
+      description: ''
+      autocalc_config: ''
 id: node.annual_foia_report_data.field_overall_vic4_avg_num_days
 field_name: field_overall_vic4_avg_num_days
 entity_type: node
@@ -15,9 +22,5 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings:
-  min: null
-  max: null
-  prefix: ''
-  suffix: ''
-field_type: decimal
+settings: {  }
+field_type: string

--- a/config/default/field.field.node.annual_foia_report_data.field_overall_vic4_high_num_days.yml
+++ b/config/default/field.field.node.annual_foia_report_data.field_overall_vic4_high_num_days.yml
@@ -1,10 +1,17 @@
-uuid: b0a239cc-1312-402c-ba1a-7574a4d35439
+uuid: 5dd7ddc6-d7e0-42a9-b8ed-cb29f2911ffc
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_overall_vic4_high_num_days
     - node.type.annual_foia_report_data
+  module:
+    - foia_autocalc
+third_party_settings:
+  foia_autocalc:
+    autocalc_settings:
+      description: ''
+      autocalc_config: ''
 id: node.annual_foia_report_data.field_overall_vic4_high_num_days
 field_name: field_overall_vic4_high_num_days
 entity_type: node
@@ -15,9 +22,5 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings:
-  min: null
-  max: null
-  prefix: ''
-  suffix: ''
-field_type: decimal
+settings: {  }
+field_type: string

--- a/config/default/field.field.node.annual_foia_report_data.field_overall_vic4_low_num_days.yml
+++ b/config/default/field.field.node.annual_foia_report_data.field_overall_vic4_low_num_days.yml
@@ -1,10 +1,17 @@
-uuid: 23f7dd73-20d6-4406-969e-047c6416d0b8
+uuid: 2592565a-cdc5-4020-9caf-da050d7e6b31
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_overall_vic4_low_num_days
     - node.type.annual_foia_report_data
+  module:
+    - foia_autocalc
+third_party_settings:
+  foia_autocalc:
+    autocalc_settings:
+      description: ''
+      autocalc_config: ''
 id: node.annual_foia_report_data.field_overall_vic4_low_num_days
 field_name: field_overall_vic4_low_num_days
 entity_type: node
@@ -15,9 +22,5 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings:
-  min: null
-  max: null
-  prefix: ''
-  suffix: ''
-field_type: decimal
+settings: {  }
+field_type: string

--- a/config/default/field.field.node.annual_foia_report_data.field_overall_vic4_med_num_days.yml
+++ b/config/default/field.field.node.annual_foia_report_data.field_overall_vic4_med_num_days.yml
@@ -1,10 +1,17 @@
-uuid: 92736c3b-edc3-4afb-8bbb-ab39b30f0234
+uuid: 876b5102-e183-4cfa-8992-6b1a14ec1d5b
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_overall_vic4_med_num_days
     - node.type.annual_foia_report_data
+  module:
+    - foia_autocalc
+third_party_settings:
+  foia_autocalc:
+    autocalc_settings:
+      description: ''
+      autocalc_config: ''
 id: node.annual_foia_report_data.field_overall_vic4_med_num_days
 field_name: field_overall_vic4_med_num_days
 entity_type: node
@@ -15,9 +22,5 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings:
-  min: null
-  max: null
-  prefix: ''
-  suffix: ''
-field_type: decimal
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.admin_app_vic4.field_avg_num_days.yml
+++ b/config/default/field.field.paragraph.admin_app_vic4.field_avg_num_days.yml
@@ -1,10 +1,17 @@
-uuid: 1c93c9ca-102e-42db-a763-5913957d6466
+uuid: 516345ae-3829-4f4d-8650-a096afc89a4d
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.paragraph.field_avg_num_days
     - paragraphs.paragraphs_type.admin_app_vic4
+  module:
+    - foia_autocalc
+third_party_settings:
+  foia_autocalc:
+    autocalc_settings:
+      description: ''
+      autocalc_config: ''
 id: paragraph.admin_app_vic4.field_avg_num_days
 field_name: field_avg_num_days
 entity_type: paragraph
@@ -15,9 +22,5 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings:
-  min: null
-  max: null
-  prefix: ''
-  suffix: ''
-field_type: decimal
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.admin_app_vic4.field_high_num_days.yml
+++ b/config/default/field.field.paragraph.admin_app_vic4.field_high_num_days.yml
@@ -1,10 +1,17 @@
-uuid: 2c3586c8-219d-4a96-9975-a9ddd366442f
+uuid: 0f2ce629-d68c-4aa2-8b39-615f97bb9b09
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.paragraph.field_high_num_days
     - paragraphs.paragraphs_type.admin_app_vic4
+  module:
+    - foia_autocalc
+third_party_settings:
+  foia_autocalc:
+    autocalc_settings:
+      description: ''
+      autocalc_config: ''
 id: paragraph.admin_app_vic4.field_high_num_days
 field_name: field_high_num_days
 entity_type: paragraph
@@ -15,9 +22,5 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings:
-  min: null
-  max: null
-  prefix: ''
-  suffix: ''
-field_type: decimal
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.admin_app_vic4.field_low_num_days.yml
+++ b/config/default/field.field.paragraph.admin_app_vic4.field_low_num_days.yml
@@ -1,10 +1,17 @@
-uuid: dccd138a-5329-4720-bd55-439b4135f7ef
+uuid: a07c1afe-9fbb-4119-9268-6756e34985d8
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.paragraph.field_low_num_days
     - paragraphs.paragraphs_type.admin_app_vic4
+  module:
+    - foia_autocalc
+third_party_settings:
+  foia_autocalc:
+    autocalc_settings:
+      description: ''
+      autocalc_config: ''
 id: paragraph.admin_app_vic4.field_low_num_days
 field_name: field_low_num_days
 entity_type: paragraph
@@ -15,9 +22,5 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings:
-  min: null
-  max: null
-  prefix: ''
-  suffix: ''
-field_type: decimal
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.admin_app_vic4.field_med_num_days.yml
+++ b/config/default/field.field.paragraph.admin_app_vic4.field_med_num_days.yml
@@ -1,10 +1,17 @@
-uuid: 83f3b34e-c9b5-4558-976d-11a256a31658
+uuid: 1b06e1da-d0e7-4551-ad94-52202d1f4887
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.paragraph.field_med_num_days
     - paragraphs.paragraphs_type.admin_app_vic4
+  module:
+    - foia_autocalc
+third_party_settings:
+  foia_autocalc:
+    autocalc_settings:
+      description: ''
+      autocalc_config: ''
 id: paragraph.admin_app_vic4.field_med_num_days
 field_name: field_med_num_days
 entity_type: paragraph
@@ -15,9 +22,5 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings:
-  min: null
-  max: null
-  prefix: ''
-  suffix: ''
-field_type: decimal
+settings: {  }
+field_type: string

--- a/config/default/field.storage.node.field_overall_vic4_avg_num_days.yml
+++ b/config/default/field.storage.node.field_overall_vic4_avg_num_days.yml
@@ -1,4 +1,4 @@
-uuid: aac555fe-d3d6-417e-a51f-076d9d613c0d
+uuid: 67f891b6-3b3b-44a1-9d0d-add8f5347126
 langcode: en
 status: true
 dependencies:
@@ -11,10 +11,11 @@ third_party_settings:
 id: node.field_overall_vic4_avg_num_days
 field_name: field_overall_vic4_avg_num_days
 entity_type: node
-type: decimal
+type: string
 settings:
-  precision: 10
-  scale: 2
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
 module: core
 locked: false
 cardinality: 1

--- a/config/default/field.storage.node.field_overall_vic4_high_num_days.yml
+++ b/config/default/field.storage.node.field_overall_vic4_high_num_days.yml
@@ -1,4 +1,4 @@
-uuid: f36a50e4-5522-4185-91e0-db7beb628b42
+uuid: 50f969d0-6a3b-4d61-b93c-ebd0d4278ecb
 langcode: en
 status: true
 dependencies:
@@ -11,10 +11,11 @@ third_party_settings:
 id: node.field_overall_vic4_high_num_days
 field_name: field_overall_vic4_high_num_days
 entity_type: node
-type: decimal
+type: string
 settings:
-  precision: 10
-  scale: 2
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
 module: core
 locked: false
 cardinality: 1

--- a/config/default/field.storage.node.field_overall_vic4_low_num_days.yml
+++ b/config/default/field.storage.node.field_overall_vic4_low_num_days.yml
@@ -1,4 +1,4 @@
-uuid: 9a55dca3-a54a-4073-902e-a26e0299b49c
+uuid: cfa1cd70-72c7-4fde-93fe-478cb2b0157c
 langcode: en
 status: true
 dependencies:
@@ -11,10 +11,11 @@ third_party_settings:
 id: node.field_overall_vic4_low_num_days
 field_name: field_overall_vic4_low_num_days
 entity_type: node
-type: decimal
+type: string
 settings:
-  precision: 10
-  scale: 2
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
 module: core
 locked: false
 cardinality: 1

--- a/config/default/field.storage.node.field_overall_vic4_med_num_days.yml
+++ b/config/default/field.storage.node.field_overall_vic4_med_num_days.yml
@@ -1,4 +1,4 @@
-uuid: 9dfb06b2-2fd6-43d2-9c1d-73e073200e12
+uuid: bb7bb523-140e-4449-8192-5979345cfc82
 langcode: en
 status: true
 dependencies:
@@ -11,10 +11,11 @@ third_party_settings:
 id: node.field_overall_vic4_med_num_days
 field_name: field_overall_vic4_med_num_days
 entity_type: node
-type: decimal
+type: string
 settings:
-  precision: 10
-  scale: 2
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
 module: core
 locked: false
 cardinality: 1

--- a/config/default/field.storage.paragraph.field_avg_num_days.yml
+++ b/config/default/field.storage.paragraph.field_avg_num_days.yml
@@ -1,4 +1,4 @@
-uuid: 7f352117-4710-4b4f-8cd0-6a337141db99
+uuid: a74608a8-24bb-4646-a93d-4247df17dce0
 langcode: en
 status: true
 dependencies:
@@ -11,10 +11,11 @@ third_party_settings:
 id: paragraph.field_avg_num_days
 field_name: field_avg_num_days
 entity_type: paragraph
-type: decimal
+type: string
 settings:
-  precision: 10
-  scale: 2
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
 module: core
 locked: false
 cardinality: 1

--- a/config/default/field.storage.paragraph.field_high_num_days.yml
+++ b/config/default/field.storage.paragraph.field_high_num_days.yml
@@ -1,4 +1,4 @@
-uuid: 1d54a1a8-a342-4475-89d4-e4397b86839a
+uuid: 0eb4d713-d6ef-4350-b30a-0995ce3d04b9
 langcode: en
 status: true
 dependencies:
@@ -11,10 +11,11 @@ third_party_settings:
 id: paragraph.field_high_num_days
 field_name: field_high_num_days
 entity_type: paragraph
-type: decimal
+type: string
 settings:
-  precision: 10
-  scale: 2
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
 module: core
 locked: false
 cardinality: 1

--- a/config/default/field.storage.paragraph.field_low_num_days.yml
+++ b/config/default/field.storage.paragraph.field_low_num_days.yml
@@ -1,4 +1,4 @@
-uuid: 30aebdde-8aec-4782-8763-070409f6a8cb
+uuid: 60304626-c7c0-4066-8e0b-53d4965ede41
 langcode: en
 status: true
 dependencies:
@@ -11,10 +11,11 @@ third_party_settings:
 id: paragraph.field_low_num_days
 field_name: field_low_num_days
 entity_type: paragraph
-type: decimal
+type: string
 settings:
-  precision: 10
-  scale: 2
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
 module: core
 locked: false
 cardinality: 1

--- a/config/default/field.storage.paragraph.field_med_num_days.yml
+++ b/config/default/field.storage.paragraph.field_med_num_days.yml
@@ -1,4 +1,4 @@
-uuid: c4d0ff41-e38b-4f41-bf9f-0a9ed2163004
+uuid: 6d64f322-b5e6-43fc-bc82-266fbb5baa48
 langcode: en
 status: true
 dependencies:
@@ -11,10 +11,11 @@ third_party_settings:
 id: paragraph.field_med_num_days
 field_name: field_med_num_days
 entity_type: paragraph
-type: decimal
+type: string
 settings:
-  precision: 10
-  scale: 2
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
 module: core
 locked: false
 cardinality: 1

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -42,8 +42,24 @@
         return value >= Number(target.val());
       }, "Please enter a greater value." );
 
+       // greaterThanEqualToNA
+      $.validator.addMethod( "greaterThanEqualToNA", function( value, element, param ) {
+        var target = convertSpecialToZero($( param ));
+        return value >= Number(convertSpecialToZero(target.val()));
+      }, "Please enter a greater value." );
+
        // greaterThanZero
        $.validator.addMethod( "greaterThanZero", function( value, element, param ) {
+        return value > 0;
+      }, "Please enter a value greater than zero." );
+
+       // greaterThanZeroOrNA
+       $.validator.addMethod( "greaterThanZeroOrNA", function( value, element, param ) {
+        switch (String(value).toLowerCase()) {
+          case "n/a":
+          case "<1":
+            return true;
+        }
         return value > 0;
       }, "Please enter a value greater than zero." );
 
@@ -163,6 +179,19 @@
         return this.optional(element) || (value >= min) && (value <= max);
       }, "Must be between the smallest and largest values.");
 
+      // betweenMinMaxCompNA
+      jQuery.validator.addMethod("betweenMinMaxCompNA", function(value, element, params) {
+        value = convertSpecialToZero(value);
+        var valuesArray = [];
+        for (var i = 0; i < params.length; i++){
+          valuesArray.push(Number(convertSpecialToZero($( params[i] ).val())));
+        }
+        var min = Math.min.apply(null, valuesArray);
+        var max = Math.max.apply(null, valuesArray);
+        return this.optional(element) || (value >= min) && (value <= max);
+      }, "Must be between the smallest and largest values.");
+
+
       // equalToLowestComp
       jQuery.validator.addMethod("equalToLowestComp", function(value, element, params) {
         var valuesArray = [];
@@ -190,6 +219,18 @@
         var average = sum/params.length;
         return this.optional(element) || !(value == average);
       }, "Must not be equal to the average.");
+
+      // notAverageCompNA
+      jQuery.validator.addMethod("notAverageCompNA", function(value, element, params) {
+        value = convertSpecialToZero(value);
+        var sum = 0;
+        for (var i = 0; i < params.length; i++){
+          sum += Number(convertSpecialToZero($( params[i] ).val()));
+        }
+        var average = sum/params.length;
+        return this.optional(element) || !(value == average);
+      }, "Must not be equal to the average.");
+
 
       // vb1matchDispositionComp: hard-coded for V.B.(1)
       jQuery.validator.addMethod("vb1matchDispositionComp", function(value, element, params) {
@@ -459,7 +500,7 @@
       // VI.C.(4) - Administrative Appeals
       $( "input[name*='field_admin_app_vic4']").filter("input[name*='field_low_num_days']").rules( "add", {
         lessThanEqualComp: $( "input[name*='field_admin_app_vic4']").filter("input[name*='field_high_num_days']"),
-        greaterThanZero: true,
+        greaterThanZeroOrNA: true,
         messages: {
           lessThanEqualComp: "Must be lower than or equal to the highest number of days."
         }
@@ -467,29 +508,29 @@
 
       // VI.C.(4) - Agency Overall Median Number of Days
       $( "#edit-field-overall-vic4-med-num-days-0-value").rules( "add", {
-        betweenMinMaxComp: $("input[name*='field_admin_app_vic4']").filter("input[name*='field_med_num_days']"),
-        notAverageComp: $("input[name*='field_admin_app_vic4']").filter("input[name*='field_med_num_days']"),
+        betweenMinMaxCompNA: $("input[name*='field_admin_app_vic4']").filter("input[name*='field_med_num_days']"),
+        notAverageCompNA: $("input[name*='field_admin_app_vic4']").filter("input[name*='field_med_num_days']"),
         messages: {
-          betweenMinMaxComp: "This field should be between the largest and smallest values of Median Number of Days",
-          notAverageComp: "Warning: should not equal to the average Median Number of Days."
+          betweenMinMaxCompNA: "This field should be between the largest and smallest values of Median Number of Days",
+          notAverageCompNA: "Warning: should not equal to the average Median Number of Days."
         }
       });
 
       // VI.C.(4) - Agency Overall Lowest Number of Days
       $( "#edit-field-overall-vic4-low-num-days-0-value").rules( "add", {
-        lessThanEqualTo: "#edit-field-overall-vic4-high-num-days-0-value",
-        greaterThanZero: true,
+        lessThanEqualToNA: "#edit-field-overall-vic4-high-num-days-0-value",
+        greaterThanZeroOrNA: true,
         messages: {
-          lessThanEqualTo: "Must be lower than or equal to the highest number of days."
+          lessThanEqualToNA: "Must be lower than or equal to the highest number of days."
         }
       });
 
       // VI.C.(4) - Agency Overall Highest Number of Days
       $( "#edit-field-overall-vic4-high-num-days-0-value").rules( "add", {
-        greaterThanEqualTo: "#edit-field-overall-vic4-low-num-days-0-value",
-        greaterThanZero: true,
+        greaterThanEqualToNA: "#edit-field-overall-vic4-low-num-days-0-value",
+        greaterThanZeroOrNA: true,
         messages: {
-          greaterThanEqualTo: "Must be greater than or equal to the lowest number of days."
+          greaterThanEqualToNA: "Must be greater than or equal to the lowest number of days."
         }
       });
 


### PR DESCRIPTION
I deleted the fields in question and then re-recreated them with the same machine names.  The validation JS had to be updated to handle "<1" as well.   Tested on a fresh DB from blt sync to make sure the configs were importing OK.