### PR TITLE
FOIA-139: Block simultaneous submissions at the form level.

### DIFF
--- a/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
@@ -8,6 +8,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\user\Entity\User;
 use Drupal\migrate_plus\Entity\Migration;
+use Drupal\migrate\Plugin\MigrationInterface;
 
 /**
  * Class AgencyXmlUploadForm.
@@ -87,7 +88,7 @@ class AgencyXmlUploadForm extends FormBase {
     $migration_clear = TRUE;
     $migration_running = '';
     foreach ($migrateStatusArr as $migration => $status) {
-      if ($status == '1') {
+      if ($status != MigrationInterface::STATUS_IDLE) {
         $migration_clear = FALSE;
         $migration_running = $migration;
       }

--- a/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
@@ -81,6 +81,26 @@ class AgencyXmlUploadForm extends FormBase {
   /**
    * {@inheritdoc}
    */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    $migrateStatus = \Drupal::keyValue('migrate_status');
+    $migrateStatusArr = $migrateStatus->getAll();
+    $migration_clear = TRUE;
+    $migration_running = '';
+    foreach ($migrateStatusArr as $migration => $status) {
+      if ($status == '1') {
+        $migration_clear = FALSE;
+        $migration_running = $migration;
+      }
+    }
+    if (!$migration_clear) {
+      $form_state->setErrorByName('submit',
+        $this->t("Another Agency's import is running; please re-submit in a few minutes."));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $fid = $form_state->getValue(['agency_report_xml', 0]);
     if (empty($fid)) {


### PR DESCRIPTION
This seems to block the ability to launch a migration if one is already running.  It's possible that by perfect timing they could still do it, but it seems to have reduced the window to nearly impossible.