### PR TITLE
FOIA-143: Display overlay when validating.

### DIFF
--- a/docroot/modules/custom/foia_ui/css/foia_ui.validation.css
+++ b/docroot/modules/custom/foia_ui/css/foia_ui.validation.css
@@ -15,3 +15,24 @@
 .vertical-tabs__menu-item.has-validation-error > a > .vertical-tabs__menu-item-title {
   color: #a51b00 !important;
 }
+
+.validation-overlay {
+  background: rgba(0, 0, 0, .5);
+  height: 100%;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 100;
+}
+
+.validation-overlay .ajax-progress {
+  left: 50%;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.validation-overlay .ajax-progress-fullscreen {
+  background-image: none;
+}

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -278,23 +278,36 @@
 
       // Disable Submit button until Validate button is clicked.
       $('input#edit-submit').prop('disabled', true);
+      $('body').append('<div id="validation-overlay"' +
+          ' class="validation-overlay hidden">' +
+          '<div class="ajax-progress ajax-progress-fullscreen">' +
+          '<img src="/core/misc/loading-small.gif" />' +
+          '</div></div>');
       $('input#edit-validate-button').on('click', function(event) {
         event.preventDefault();
+
+        $('.validation-overlay').removeClass('hidden');
 
         // To validate select drop-downs as required, they must have an
         // empty machine value.
         $("select > option[value='_none']").val('');
 
-        // Validate form
-        $(drupalSettings.foiaUI.foiaUISettings.formID).valid();
 
-        // Empty drop-downs can still be submitted though, so restore
-        // Drupal's default empty drop-down value to avoid "An illegal
-        // choice has been detected" error in that scenario.
-        $("select > option[value='']").val('_none');
+        // Allow some time for the overlay to render.
+        setTimeout(function() {
+          // Validate form
+          $(drupalSettings.foiaUI.foiaUISettings.formID).valid();
 
-        // Enable form Save button
-        $('input#edit-submit').prop('disabled', false);
+          $('.validation-overlay').addClass('hidden');
+
+          // Empty drop-downs can still be submitted though, so restore
+          // Drupal's default empty drop-down value to avoid "An illegal
+          // choice has been detected" error in that scenario.
+          $("select > option[value='']").val('_none');
+
+          // Enable form Save button
+          $('input#edit-submit').prop('disabled', false);
+        }, 100);
       });
 
       /**


### PR DESCRIPTION
* Displays an overlay on the node form while the validator is running.  
* Moves the `valid()` call into a timeout so that the overlay has time to render before the validation starts running.  The overlay (or a throbber) won't display otherwise.