### PR TITLE
FOIA-178: Increase memory limit on Annual Reports.

### DIFF
--- a/docroot/modules/custom/foia_annual_data_report/config/install/foia_annual_data_report.settings.yml
+++ b/docroot/modules/custom/foia_annual_data_report/config/install/foia_annual_data_report.settings.yml
@@ -1,0 +1,2 @@
+annual_report_memory_limit: 1024M
+debug_annual_report_memory_limit: 0

--- a/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.links.menu.yml
+++ b/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.links.menu.yml
@@ -1,0 +1,6 @@
+foia_annual_data_report.settings:
+  title: FOIA Annual Data Report Memory Limit Settings
+  description: 'Set PHP memory limit values for FOIA Annual Data Report nodes.'
+  parent: system.admin_config_system
+  route_name: foia_annual_data_report.memory_limit
+  weight: 10

--- a/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
+++ b/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
@@ -13,6 +13,11 @@ use Drupal\Core\Url;
 use Drupal\Core\Ajax\RedirectCommand;
 
 /**
+ * Memory limit to be used for viewing/submitting Annual Report nodes.
+ */
+define('FOIA_ANNUAL_DATA_REPORT_MEMORY_LIMIT', '1024M');
+
+/**
  * Implements hook_form_form_id_alter().
  */
 function foia_annual_data_report_form_node_annual_foia_report_data_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
@@ -151,5 +156,24 @@ function foia_annual_data_report_refresh(array $form, FormStateInterface
  * Set the memory limit to 1024M. Should only be used on Annual Report forms.
  */
 function foia_annual_data_report_early_submit($form, FormStateInterface $form_state) {
-  ini_set('memory_limit', '1024M');
+  ini_set('memory_limit', FOIA_ANNUAL_DATA_REPORT_MEMORY_LIMIT);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_load().
+ */
+function foia_annual_data_report_node_load($entities) {
+  // If there is an Annual Report being loaded and memory is not what we want
+  // then set it.
+  if (ini_get('memory_limit') !== FOIA_ANNUAL_DATA_REPORT_MEMORY_LIMIT) {
+    foreach ($entities as $entity) {
+      if ($entity->bundle() === 'annual_foia_report_data') {
+
+        ini_set('memory_limit', FOIA_ANNUAL_DATA_REPORT_MEMORY_LIMIT);
+
+        // If we already set the memory limit, break out of the array.
+        break;
+      }
+    }
+  }
 }

--- a/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
+++ b/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
@@ -16,7 +16,16 @@ use Drupal\Core\Ajax\RedirectCommand;
  * Implements hook_form_form_id_alter().
  */
 function foia_annual_data_report_form_node_annual_foia_report_data_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Add the AJAX save callbacks.
   foia_annual_data_report_ajax_existing_node($form);
+
+  // Force a submit function to increase memory limit before core's submit.
+  foreach (array_keys($form['actions']) as $action) {
+    if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
+      array_unshift($form['actions'][$action]['#submit'], 'foia_annual_data_report_early_submit');
+    }
+  }
+
 }
 
 /**
@@ -134,4 +143,13 @@ function foia_annual_data_report_refresh(array $form, FormStateInterface
   }
 
   return $response;
+}
+
+/**
+ * Implements hook_form_submit().
+ *
+ * Set the memory limit to 1024M. Should only be used on Annual Report forms.
+ */
+function foia_annual_data_report_early_submit($form, FormStateInterface $form_state) {
+  ini_set('memory_limit', '1024M');
 }

--- a/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
+++ b/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
@@ -13,11 +13,6 @@ use Drupal\Core\Url;
 use Drupal\Core\Ajax\RedirectCommand;
 
 /**
- * Memory limit to be used for viewing/submitting Annual Report nodes.
- */
-define('FOIA_ANNUAL_DATA_REPORT_MEMORY_LIMIT', '1024M');
-
-/**
  * Implements hook_form_form_id_alter().
  */
 function foia_annual_data_report_form_node_annual_foia_report_data_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
@@ -156,7 +151,10 @@ function foia_annual_data_report_refresh(array $form, FormStateInterface
  * Set the memory limit to 1024M. Should only be used on Annual Report forms.
  */
 function foia_annual_data_report_early_submit($form, FormStateInterface $form_state) {
-  ini_set('memory_limit', FOIA_ANNUAL_DATA_REPORT_MEMORY_LIMIT);
+  foia_annual_data_report_debug_log('Submitting Annual Report. Before setting memory');
+  foia_annual_data_report_set_memory_limit();
+  foia_annual_data_report_debug_log('Submitting Annual Report. After setting memory');
+
 }
 
 /**
@@ -165,15 +163,69 @@ function foia_annual_data_report_early_submit($form, FormStateInterface $form_st
 function foia_annual_data_report_node_load($entities) {
   // If there is an Annual Report being loaded and memory is not what we want
   // then set it.
-  if (ini_get('memory_limit') !== FOIA_ANNUAL_DATA_REPORT_MEMORY_LIMIT) {
+  if (ini_get('memory_limit') !== foia_annual_data_report_get_config('annual_report_memory_limit')) {
     foreach ($entities as $entity) {
       if ($entity->bundle() === 'annual_foia_report_data') {
 
-        ini_set('memory_limit', FOIA_ANNUAL_DATA_REPORT_MEMORY_LIMIT);
+        foia_annual_data_report_debug_log('Loading Annual Report. Before setting memory');
+        foia_annual_data_report_set_memory_limit();
+        foia_annual_data_report_debug_log('Loading Annual Report. After setting memory');
 
         // If we already set the memory limit, break out of the array.
         break;
       }
     }
+  }
+}
+
+/**
+ * Set memory limit for override based on config.
+ */
+function foia_annual_data_report_set_memory_limit() {
+  try {
+    $config_value = foia_annual_data_report_get_config('annual_report_memory_limit');
+  }
+  catch (\InvalidArgumentException $e) {
+    \Drupal::logger('foia_annual_data_report')->error('Invalid setting requested.');
+  }
+
+  if ($config_value) {
+    ini_set('memory_limit', $config_value);
+  }
+}
+
+/**
+ * Get the requested setting from this module's config.
+ *
+ * @param string $setting
+ *   The name of the setting to be retrieved.
+ *
+ * @return string
+ *   The value of the requested setting.
+ */
+function foia_annual_data_report_get_config(string $setting) {
+  if (!in_array($setting, ['annual_report_memory_limit', 'debug_annual_report_memory_limit'])) {
+    throw new \InvalidArgumentException('Invalid setting.');
+  }
+  $value = \Drupal::config('foia_annual_data_report.settings')
+    ->get($setting);
+
+  return $value;
+}
+
+/**
+ * Log debugging output if config value is set.
+ *
+ * @param string $message_base
+ *   Base text to prepend to memory_limit when writing debugging message.
+ */
+function foia_annual_data_report_debug_log(string $message_base) {
+  $debug = foia_annual_data_report_get_config('debug_annual_report_memory_limit');
+
+  if ($debug) {
+
+    $msg = $message_base . ': ' . ini_get('memory_limit');
+
+    \Drupal::logger('foia_annual_data_report')->debug($msg);
   }
 }

--- a/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.routing.yml
+++ b/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.routing.yml
@@ -1,0 +1,7 @@
+foia_annual_data_report.memory_limit:
+  path: '/admin/config/system/foia_annual_data_report_memory_limit'
+  defaults:
+    _title: 'FOIA Annual Data Report Memory Limit Settings'
+    _form: 'Drupal\foia_annual_data_report\Form\MemoryLimitForm'
+  requirements:
+    _permission: 'administer site configuration'

--- a/docroot/modules/custom/foia_annual_data_report/src/Form/MemoryLimitForm.php
+++ b/docroot/modules/custom/foia_annual_data_report/src/Form/MemoryLimitForm.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\foia_annual_data_report\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Configure foia_annual_data_report settings for this site.
+ *
+ * @todo Validate the memory limit setting. Int or int followed by K, M, or G.
+ */
+class MemoryLimitForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'foia_annual_data_report_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['foia_annual_data_report.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['annual_report_memory_limit'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Annual Report Memory Limit'),
+      '#default_value' => $this->config('foia_annual_data_report.settings')->get('annual_report_memory_limit'),
+      '#description' => $this->t('Leave blank for no override. If set, make sure this value is valid per PHPs memory limit options.'),
+    ];
+    $form['debug_annual_report_memory_limit'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Debug Annual Report memory limit.'),
+      '#default_value' => $this->config('foia_annual_data_report.settings')->get('debug_annual_report_memory_limit'),
+      '#description' => $this->t('When set `debug` entries will be written to log files to verify the module is working.'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('foia_annual_data_report.settings')
+      ->set('annual_report_memory_limit', $form_state->getValue('annual_report_memory_limit'))
+      ->save();
+    $this->config('foia_annual_data_report.settings')
+      ->set('debug_annual_report_memory_limit', $form_state->getValue('debug_annual_report_memory_limit'))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}


### PR DESCRIPTION
Using array_unshift to get our submit function to run in front of core's feels skeevy, but it works; as implemented, it even fires before [hook_entity_presave()](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Entity%21entity.api.php/function/hook_entity_presave/8.2.x).

What still needs to be addressed is increasing it when loading the entity in either view or edit modes.