### PR TITLE
FOIA-167: Let low and high value comps accept <1.

### DIFF
--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -198,18 +198,20 @@
 
       // equalToLowestComp
       jQuery.validator.addMethod("equalToLowestComp", function(value, element, params) {
+        value = convertSpecialToZero(value);
         var valuesArray = [];
         for (var i = 0; i < params.length; i++){
-          valuesArray.push(Number($( params[i] ).val()));
+          valuesArray.push(Number(convertSpecialToZero($( params[i] ).val())));
         }
         return this.optional(element) || (value == Math.min.apply(null, valuesArray));
       }, "Must equal the lowest value.");
 
       // equalToHighestComp
       jQuery.validator.addMethod("equalToHighestComp", function(value, element, params) {
+        value = convertSpecialToZero(value);
         var valuesArray = [];
         for (var i = 0; i < params.length; i++){
-          valuesArray.push(Number($( params[i] ).val()));
+          valuesArray.push(Number(convertSpecialToZero($( params[i] ).val())));
         }
         return this.optional(element) || (value == Math.max.apply(null, valuesArray));
       }, "Must equal the highest value.");


### PR DESCRIPTION
Include convertSpecialToZero method in equalToLowestComp and
equalToHighestComp validations, making values of <1 equivalent to 0.