### PR TITLE
FOIA-169: Order of 10 Oldest per component validation

### DIFF
--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -1167,80 +1167,20 @@
         }
       });
 
-      // For the next 9 rules, each is comparing the value to the one lower
-      // than it ( i.e., field 10 is less than field 9, field 9 is less than
-      // field 8, etc).  This is the agency component part of the form.
-      // XII.C. (Agency Components) CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 10th
-      $( "#edit-field-foia-xiic-0-subform-field-num-days-10-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-foia-xiic-0-subform-field-num-days-9-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"9th\"."
-        }
-      });
-
-      // XII.C. (Agency Components) CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 9th
-      $( "#edit-field-foia-xiic-0-subform-field-num-days-9-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-foia-xiic-0-subform-field-num-days-8-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"8th\"."
-        }
-      });
-
-      // XII.C. (Agency Components) CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 8th
-      $( "#edit-field-foia-xiic-0-subform-field-num-days-8-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-foia-xiic-0-subform-field-num-days-7-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"7th\"."
-        }
-      });
-
-      // XII.C. (Agency Components) CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 7th
-      $( "#edit-field-foia-xiic-0-subform-field-num-days-7-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-foia-xiic-0-subform-field-num-days-6-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"6th\"."
-        }
-      });
-
-      // XII.C. (Agency Components) CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 6th
-      $( "#edit-field-foia-xiic-0-subform-field-num-days-6-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-foia-xiic-0-subform-field-num-days-5-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"5th\"."
-        }
-      });
-
-      // XII.C. (Agency Components) CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 5th
-      $( "#edit-field-foia-xiic-0-subform-field-num-days-5-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-foia-xiic-0-subform-field-num-days-4-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"4th\"."
-        }
-      });
-
-      // XII.C. (Agency Components) CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 4th
-      $( "#edit-field-foia-xiic-0-subform-field-num-days-4-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-foia-xiic-0-subform-field-num-days-3-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"3d\"."
-        }
-      });
-
-      // XII.C. (Agency Components) CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 3d
-      $( "#edit-field-foia-xiic-0-subform-field-num-days-3-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-foia-xiic-0-subform-field-num-days-2-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"2d\"."
-        }
-      });
-
-      // XII.C. (Agency Components) CONSULTATIONS ON FOIA REQUESTS -- TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY / 2d
-      $( "#edit-field-foia-xiic-0-subform-field-num-days-2-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-foia-xiic-0-subform-field-num-days-1-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"Overall\"."
-        }
-      });
+      // XII.C. FOIA Requests and Administrative Appeals - Oldest Days component/ 2nd-10th
+      // For each Agency/Component, iterate over 2nd to 10th Oldest days
+      // comparing the value to the one before it, e.g. value of 9th <= 8th.
+      for (var i = 2; i <= 10; i++){
+        priorOrdinal = ordinalNumber(i - 1);
+        $("input[name*='field_foia_xiic']").filter("input[name*='field_num_days_" + i + "']").each(function() {
+          $(this).rules( "add", {
+            lessThanEqualOlderComp: 'field_num_days_' + String(i-1),
+            messages: {
+              lessThanEqualOlderComp: "This should be less than the number of days for <em>" + priorOrdinal + "</em>."
+            }
+          });
+        });
+      }
 
       // XII.D.(1). Number Received During Fiscal Year from Current Annual Report
       $( "input[name*='field_foia_xiid1']").filter("input[name*='field_received_cur_yr']").each(function() {

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -681,12 +681,9 @@
         }
       });
 
-      // VI.C. (5) - Agency Components
-      // For the next 9 rules, each is comparing the value to the one lower
-      // than it ( i.e., field 10 is less than field 9, field 9 is less than
-      // field 8, etc).  Unlike the above group, this is for the agency
-      // component part of the form.
-      // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 10th
+      // VI.C. (5) - ADMINISTRATIVE APPEALS - Oldest Days component/ 2nd-10th
+      // For each Agency/Component, iterate over 2nd to 10th Oldest days
+      // comparing the value to the one before it, e.g. value of 9th <= 10th.
       for (var i = 2; i <= 10; i++){
         priorOrdinal = ordinalNumber(i - 1);
         $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_" + i + "']").each(function() {

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -661,75 +661,75 @@
       // field 8, etc).  Unlike the above group, this is for the agency
       // component part of the form.
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 10th
-      $( "#edit-field-admin-app-vic5-0-subform-field-num-days-10-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-admin-app-vic5-0-subform-field-num-days-9-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"9th\"."
-        }
+      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_10']").rules( "add", {
+          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_9']"),
+          messages: {
+              lessThanEqualToNA: "This should be less than the number of days for \"9th\"."
+          }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 9th
-      $( "#edit-field-admin-app-vic5-0-subform-field-num-days-9-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-admin-app-vic5-0-subform-field-num-days-8-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"8th\"."
-        }
+      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_9']").rules( "add", {
+          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_8']"),
+          messages: {
+              lessThanEqualToNA: "This should be less than the number of days for \"8th\"."
+          }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 8th
-      $( "#edit-field-admin-app-vic5-0-subform-field-num-days-8-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-admin-app-vic5-0-subform-field-num-days-7-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"7th\"."
-        }
+      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_8']").rules( "add", {
+          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_7']"),
+          messages: {
+              lessThanEqualToNA: "This should be less than the number of days for \"7th\"."
+          }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 7th
-      $( "#edit-field-admin-app-vic5-0-subform-field-num-days-7-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-admin-app-vic5-0-subform-field-num-days-6-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"6th\"."
-        }
+      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_7']").rules( "add", {
+          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_6']"),
+          messages: {
+              lessThanEqualToNA: "This should be less than the number of days for \"6th\"."
+          }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 6th
-      $( "#edit-field-admin-app-vic5-0-subform-field-num-days-6-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-admin-app-vic5-0-subform-field-num-days-5-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"5th\"."
-        }
+      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_6']").rules( "add", {
+          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_5']"),
+          messages: {
+              lessThanEqualToNA: "This should be less than the number of days for \"5th\"."
+          }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 5th
-      $( "#edit-field-admin-app-vic5-0-subform-field-num-days-5-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-admin-app-vic5-0-subform-field-num-days-4-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"4th\"."
-        }
+      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_5']").rules( "add", {
+          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_4']"),
+          messages: {
+              lessThanEqualToNA: "This should be less than the number of days for \"4th\"."
+          }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 4th
-      $( "#edit-field-admin-app-vic5-0-subform-field-num-days-4-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-admin-app-vic5-0-subform-field-num-days-3-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"3rd\"."
-        }
+      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_4']").rules( "add", {
+          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_3']"),
+          messages: {
+              lessThanEqualToNA: "This should be less than the number of days for \"3rd\"."
+          }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 3rd
-      $( "#edit-field-admin-app-vic5-0-subform-field-num-days-3-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-admin-app-vic5-0-subform-field-num-days-2-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"2nd\"."
-        }
+      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_3']").rules( "add", {
+          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_2']"),
+          messages: {
+              lessThanEqualToNA: "This should be less than the number of days for \"2nd\"."
+          }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 2nd
-      $( "#edit-field-admin-app-vic5-0-subform-field-num-days-2-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-admin-app-vic5-0-subform-field-num-days-1-0-value",
-        messages: {
-          lessThanEqualToNA: "This should be less than the number of days for \"Oldest\"."
-        }
+      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_2']").rules( "add", {
+          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_1']"),
+          messages: {
+              lessThanEqualToNA: "This should be less than the number of days for \"Overall\"."
+          }
       });
 
       // VII.A. Simple - Agency Overall Median Number of Days

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -1037,17 +1037,6 @@
         });
       });
 
-
-      // XII.C. FOIA Requests and Administrative Appeals
-      $("input[name*='field_foia_xiic']").filter("input[name*='field_num_days_1']").each(function() {
-        $(this).rules( "add", {
-          ifGreaterThanZeroComp: $("input[name*='field_foia_xiib']").filter("input[name*='field_pend_end_yr']"),
-          messages: {
-            ifGreaterThanZeroComp: "If there are consultations pending at end of year for XII.B, there must be entries in this section for that component.",
-          }
-        });
-      });
-
       // XII.A. Number of Backlogged Requests as of End of Fiscal Year
       $( "input[name*='field_foia_xiia']").filter("input[name*='field_back_req_end_yr']").each(function() {
         $(this).rules( "add", {
@@ -1090,6 +1079,16 @@
         messages: {
           lessThanEqualToNA: "Must be equal to or less than VI.A.(1). Agency Overall Number of Appeals Pending as of End of Fiscal Year",
         }
+      });
+
+      // XII.C. FOIA Requests and Administrative Appeals
+      $("input[name*='field_foia_xiic']").filter("input[name*='field_num_days_1']").each(function() {
+        $(this).rules( "add", {
+          ifGreaterThanZeroComp: $("input[name*='field_foia_xiib']").filter("input[name*='field_pend_end_yr']"),
+          messages: {
+            ifGreaterThanZeroComp: "If there are consultations pending at end of year for XII.B, there must be entries in this section for that component.",
+          }
+        });
       });
 
       // For the next 9 rules, each is comparing the value to the one lower

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -689,11 +689,13 @@
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 10th
       for (var i = 2; i <= 10; i++){
         priorOrdinal = ordinalNumber(i - 1);
-        $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_" + i + "']").rules( "add", {
-          lessThanEqualOlderComp: 'field_num_days_' + String(i-1),
-          messages: {
-            lessThanEqualOlderComp: "This should be less than the number of days for <em>" + priorOrdinal + "</em>."
-          }
+        $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_" + i + "']").each(function() {
+          $(this).rules( "add", {
+            lessThanEqualOlderComp: 'field_num_days_' + String(i-1),
+            messages: {
+              lessThanEqualOlderComp: "This should be less than the number of days for <em>" + priorOrdinal + "</em>."
+            }
+          });
         });
       }
 

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -683,7 +683,7 @@
 
       // VI.C. (5) - ADMINISTRATIVE APPEALS - Oldest Days component/ 2nd-10th
       // For each Agency/Component, iterate over 2nd to 10th Oldest days
-      // comparing the value to the one before it, e.g. value of 9th <= 10th.
+      // comparing the value to the one before it, e.g. value of 9th <= 8th.
       for (var i = 2; i <= 10; i++){
         priorOrdinal = ordinalNumber(i - 1);
         $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_" + i + "']").each(function() {

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -161,6 +161,27 @@
         }
       }, "Must be less than or equal to a field.");
 
+      // lessThanEqualMultiComp
+      // initElementId is the id for the given field/element on the initial paragraph
+      // example initElementId: #edit-field-foia-xiic-0-subform-field-num-days-4-0-value
+      jQuery.validator.addMethod("lessThanEqualMultiComp", function(value, initElementId, params) {
+          value = convertSpecialToZero(value);
+          findIndex = element.indexOf('-subform-');
+          elementEnd = element.substr(findIndex);
+          elementStart = element.substr(0,findIndex);
+          findIndex = lastIndexOf(elementStart)+1;
+          elementIndex = elementStart.substring(findIndex).valueof();
+          elementStart = elementStart.substring(0,findIndex);
+          var elementAgencyComponent = $(element).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+          for (var i = 0; i < params.length; i++){
+              var paramAgencyComponent = $(params[i]).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+              if (paramAgencyComponent == elementAgencyComponent) {
+                  var target = Number(convertSpecialToZero($( params[i] ).val()));
+                  return this.optional(element) || value <= target;
+              }
+          }
+      }, "Must be less than or equal to a field.");
+
       // greaterThanEqualComp
       jQuery.validator.addMethod("greaterThanEqualComp", function(value, element, params) {
         var elementAgencyComponent = $(element).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -21,12 +21,12 @@
       }
 
       /**
-       * Get ordinal number with suffix
+       * Return Oldest Days ordinal number with suffix
        */
-      function ordinalNumber(value) {
+      function oldestOrdinal(value) {
         switch (value) {
           case 1:
-            return value + "st";
+            return "Oldest";
             break;
           case 2:
             return value + "nd"
@@ -685,7 +685,7 @@
       // For each Agency/Component, iterate over 2nd to 10th Oldest days
       // comparing the value to the one before it, e.g. value of 9th <= 8th.
       for (var i = 2; i <= 10; i++){
-        priorOrdinal = ordinalNumber(i - 1);
+        priorOrdinal = oldestOrdinal(i - 1);
         $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_" + i + "']").each(function() {
           $(this).rules( "add", {
             lessThanEqualOlderComp: 'field_num_days_' + String(i-1),
@@ -1170,7 +1170,7 @@
       // For each Agency/Component, iterate over 2nd to 10th Oldest days
       // comparing the value to the one before it, e.g. value of 9th <= 8th.
       for (var i = 2; i <= 10; i++){
-        priorOrdinal = ordinalNumber(i - 1);
+        priorOrdinal = oldestOrdinal(i - 1);
         $("input[name*='field_foia_xiic']").filter("input[name*='field_num_days_" + i + "']").each(function() {
           $(this).rules( "add", {
             lessThanEqualOlderComp: 'field_num_days_' + String(i-1),

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -21,6 +21,25 @@
       }
 
       /**
+       * Get ordinal number with suffix
+       */
+      function ordinalNumber(value) {
+        switch (value) {
+          case 1:
+            return value + "st";
+            break;
+          case 2:
+            return value + "nd"
+            break;
+          case 3:
+            return value + "rd"
+            break;
+          default:
+            return value + "th"
+        }
+      }
+
+      /**
        * Checks that a date is in the format of YYYY-MM-DD
        *
        * @param dateString
@@ -161,25 +180,11 @@
         }
       }, "Must be less than or equal to a field.");
 
-      // lessThanEqualMultiComp
-      // initElementId is the id for the given field/element on the initial paragraph
-      // example initElementId: #edit-field-foia-xiic-0-subform-field-num-days-4-0-value
-      jQuery.validator.addMethod("lessThanEqualMultiComp", function(value, initElementId, params) {
+      // lessThanEqualOlderComp
+      jQuery.validator.addMethod("lessThanEqualOlderComp", function(value, element, params) {
           value = convertSpecialToZero(value);
-          findIndex = element.indexOf('-subform-');
-          elementEnd = element.substr(findIndex);
-          elementStart = element.substr(0,findIndex);
-          findIndex = lastIndexOf(elementStart)+1;
-          elementIndex = elementStart.substring(findIndex).valueof();
-          elementStart = elementStart.substring(0,findIndex);
-          var elementAgencyComponent = $(element).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
-          for (var i = 0; i < params.length; i++){
-              var paramAgencyComponent = $(params[i]).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
-              if (paramAgencyComponent == elementAgencyComponent) {
-                  var target = Number(convertSpecialToZero($( params[i] ).val()));
-                  return this.optional(element) || value <= target;
-              }
-          }
+          var target = $(element).parents('.paragraphs-subform').find("input[name*='" + params + "']").val();
+          return this.optional(element) || value <= target;
       }, "Must be less than or equal to a field.");
 
       // greaterThanEqualComp
@@ -682,76 +687,15 @@
       // field 8, etc).  Unlike the above group, this is for the agency
       // component part of the form.
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 10th
-      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_10']").rules( "add", {
-          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_9']"),
+      for (var i = 2; i <= 10; i++){
+        priorOrdinal = ordinalNumber(i - 1);
+        $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_" + i + "']").rules( "add", {
+          lessThanEqualOlderComp: 'field_num_days_' + String(i-1),
           messages: {
-            lessThanEqualComp: "This should be less than the number of days for \"9th\"."
+            lessThanEqualOlderComp: "This should be less than the number of days for <em>" + priorOrdinal + "</em>."
           }
-      });
-
-      // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 9th
-      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_9']").rules( "add", {
-          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_8']"),
-          messages: {
-            lessThanEqualComp: "This should be less than the number of days for \"8th\"."
-          }
-      });
-
-      // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 8th
-      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_8']").rules( "add", {
-          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_7']"),
-          messages: {
-            lessThanEqualComp: "This should be less than the number of days for \"7th\"."
-          }
-      });
-
-      // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 7th
-      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_7']").rules( "add", {
-          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_6']"),
-          messages: {
-              lessThanEqualComp: "This should be less than the number of days for \"6th\"."
-          }
-      });
-
-      // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 6th
-      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_6']").rules( "add", {
-          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_5']"),
-          messages: {
-              lessThanEqualComp: "This should be less than the number of days for \"5th\"."
-          }
-      });
-
-      // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 5th
-      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_5']").rules( "add", {
-          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_4']"),
-          messages: {
-              lessThanEqualComp: "This should be less than the number of days for \"4th\"."
-          }
-      });
-
-      // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 4th
-      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_4']").rules( "add", {
-          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_3']"),
-          messages: {
-              lessThanEqualComp: "This should be less than the number of days for \"3rd\"."
-          }
-      });
-
-      // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 3rd
-      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_3']").rules( "add", {
-          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_2']"),
-          messages: {
-              lessThanEqualComp: "This should be less than the number of days for \"2nd\"."
-          }
-      });
-
-      // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 2nd
-      $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_2']").rules( "add", {
-          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_1']"),
-          messages: {
-              lessThanEqualComp: "This should be less than the number of days for \"Overall\"."
-          }
-      });
+        });
+      }
 
       // VII.A. Simple - Agency Overall Median Number of Days
       $( "#edit-field-overall-viia-sim-med-0-value").rules( "add", {

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -662,73 +662,73 @@
       // component part of the form.
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 10th
       $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_10']").rules( "add", {
-          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_9']"),
+          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_9']"),
           messages: {
-              lessThanEqualToNA: "This should be less than the number of days for \"9th\"."
+            lessThanEqualComp: "This should be less than the number of days for \"9th\"."
           }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 9th
       $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_9']").rules( "add", {
-          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_8']"),
+          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_8']"),
           messages: {
-              lessThanEqualToNA: "This should be less than the number of days for \"8th\"."
+            lessThanEqualComp: "This should be less than the number of days for \"8th\"."
           }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 8th
       $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_8']").rules( "add", {
-          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_7']"),
+          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_7']"),
           messages: {
-              lessThanEqualToNA: "This should be less than the number of days for \"7th\"."
+            lessThanEqualComp: "This should be less than the number of days for \"7th\"."
           }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 7th
       $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_7']").rules( "add", {
-          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_6']"),
+          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_6']"),
           messages: {
-              lessThanEqualToNA: "This should be less than the number of days for \"6th\"."
+              lessThanEqualComp: "This should be less than the number of days for \"6th\"."
           }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 6th
       $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_6']").rules( "add", {
-          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_5']"),
+          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_5']"),
           messages: {
-              lessThanEqualToNA: "This should be less than the number of days for \"5th\"."
+              lessThanEqualComp: "This should be less than the number of days for \"5th\"."
           }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 5th
       $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_5']").rules( "add", {
-          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_4']"),
+          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_4']"),
           messages: {
-              lessThanEqualToNA: "This should be less than the number of days for \"4th\"."
+              lessThanEqualComp: "This should be less than the number of days for \"4th\"."
           }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 4th
       $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_4']").rules( "add", {
-          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_3']"),
+          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_3']"),
           messages: {
-              lessThanEqualToNA: "This should be less than the number of days for \"3rd\"."
+              lessThanEqualComp: "This should be less than the number of days for \"3rd\"."
           }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 3rd
       $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_3']").rules( "add", {
-          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_2']"),
+          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_2']"),
           messages: {
-              lessThanEqualToNA: "This should be less than the number of days for \"2nd\"."
+              lessThanEqualComp: "This should be less than the number of days for \"2nd\"."
           }
       });
 
       // VI.C.(5). (Component) TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 2nd
       $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_2']").rules( "add", {
-          lessThanEqualToNA: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_1']"),
+          lessThanEqualComp: $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_1']"),
           messages: {
-              lessThanEqualToNA: "This should be less than the number of days for \"Overall\"."
+              lessThanEqualComp: "This should be less than the number of days for \"Overall\"."
           }
       });
 

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -182,9 +182,9 @@
 
       // lessThanEqualOlderComp
       jQuery.validator.addMethod("lessThanEqualOlderComp", function(value, element, params) {
-          value = convertSpecialToZero(value);
-          var target = $(element).parents('.paragraphs-subform').find("input[name*='" + params + "']").val();
-          return this.optional(element) || value <= target;
+        value = Number(convertSpecialToZero(value));
+        var target = Number($(element).parents('.paragraphs-subform').find("input[name*='" + params + "']").val());
+        return this.optional(element) || value <= target;
       }, "Must be less than or equal to a field.");
 
       // greaterThanEqualComp

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -981,6 +981,21 @@
         }
       });
 
+      // VII.E. PENDING REQUESTS - Oldest Days component/ 2nd-10th
+      // For each Agency/Component, iterate over 2nd to 10th Oldest days
+      // comparing the value to the one before it, e.g. value of 9th <= 8th.
+      for (var i = 2; i <= 10; i++){
+        priorOrdinal = oldestOrdinal(i - 1);
+        $("input[name*='field_admin_app_viie']").filter("input[name*='field_num_days_" + i + "']").each(function() {
+          $(this).rules( "add", {
+            lessThanEqualOlderComp: 'field_num_days_' + String(i-1),
+            messages: {
+              lessThanEqualOlderComp: "This should be less than the number of days for <em>" + priorOrdinal + "</em>."
+            }
+          });
+        });
+      }
+
       // VIII.A. Agency Overall Median Number of Days to Adjudicate
       $( "#edit-field-overall-viiia-med-days-jud-0-value").rules( "add", {
         betweenMinMaxComp: $("input[name*='field_req_viiia']").filter("input[name*='field_med_days_jud']"),


### PR DESCRIPTION
Adds per agency/component validation for the Oldest Days paragraph type in the following sections

- VI.C.(5). TEN OLDEST PENDING ADMINISTRATIVE APPEALS
- VII.E. PENDING REQUESTS
- XII.C. CONSULTATIONS ON FOIA REQUESTS 
