### PR TITLE
Foia 190 broken aria reference

### DIFF
--- a/docroot/modules/custom/foia_ui/css/foia_ui_admin.css
+++ b/docroot/modules/custom/foia_ui/css/foia_ui_admin.css
@@ -5,3 +5,19 @@
 .vertical-tabs__menu-item > a {
   color: #006EB3;
 }
+
+.field--name-moderation-state fieldset:not(.fieldgroup) {
+  background-color: transparent;
+  border: 0;
+  padding: 0;
+}
+
+.field--name-moderation-state fieldset:not(.fieldgroup) > legend,
+.field--name-moderation-state fieldset:not(.fieldgroup) .fieldset-wrapper > .description {
+  position: absolute !important;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  width: 1px;
+  height: 1px;
+  word-wrap: normal;
+}

--- a/docroot/modules/custom/foia_ui/foia_ui.module
+++ b/docroot/modules/custom/foia_ui/foia_ui.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Url;
+use Drupal\Core\Render\Element;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -76,6 +77,12 @@ function foia_ui_form_node_annual_foia_report_data_edit_form_alter(&$form, FormS
   $form['meta']['author']['#markup'] = "<h4 class='label inline'>" . $form['meta']['author']['#title'] . "</h4> " . $form['meta']['author']['#markup'];
   unset($form['meta']['changed']['#title']);
   unset($form['meta']['author']['#title']);
+
+  // Wrap the moderation state form element in a fieldset so that it's
+  // description is displayed, fixing broken aria-described by references.
+  foreach (Element::children($form['moderation_state']['widget']) as $key => $element) {
+    $form['moderation_state']['widget'][$key]['#theme_wrappers'][] = 'fieldset';
+  }
 }
 
 /**
@@ -105,8 +112,10 @@ function foia_ui_form_node_annual_foia_report_data_form_alter(&$form, FormStateI
   unset($form['meta']['changed']['#title']);
   unset($form['meta']['author']['#title']);
 
-  foreach (\Drupal\Core\Render\Element::children($form['moderation_state']['widget']) as $id => $widget) {
-    $form['moderation_state']['widget'][$id]['#theme_wrappers'][] = 'fieldset';
+  // Wrap the moderation state form element in a fieldset so that it's
+  // description is displayed, fixing broken aria-described by references.
+  foreach (Element::children($form['moderation_state']['widget']) as $key => $element) {
+    $form['moderation_state']['widget'][$key]['#theme_wrappers'][] = 'fieldset';
   }
 }
 

--- a/docroot/modules/custom/foia_ui/foia_ui.module
+++ b/docroot/modules/custom/foia_ui/foia_ui.module
@@ -104,6 +104,10 @@ function foia_ui_form_node_annual_foia_report_data_form_alter(&$form, FormStateI
   $form['meta']['author']['#markup'] = "<h4 class='label inline'>" . $form['meta']['author']['#title'] . "</h4> " . $form['meta']['author']['#markup'];
   unset($form['meta']['changed']['#title']);
   unset($form['meta']['author']['#title']);
+
+  foreach (\Drupal\Core\Render\Element::children($form['moderation_state']['widget']) as $id => $widget) {
+    $form['moderation_state']['widget'][$id]['#theme_wrappers'][] = 'fieldset';
+  }
 }
 
 /**


### PR DESCRIPTION
- Wrap moderation state fields in a fieldset so that the description is
displayed, fixing broken aria-describedby references.
- Maintain the moderation state fields admin display by overriding some
fieldset css and visually hiding the description and legend.