### PR TITLE
Foia 200 validation js performance

### DIFF
--- a/config/default/core.entity_form_display.node.annual_foia_report_data.default.yml
+++ b/config/default/core.entity_form_display.node.annual_foia_report_data.default.yml
@@ -1608,9 +1608,9 @@ third_party_settings:
       weight: 1
       format_type: tabs
       format_settings:
-        id: ''
-        classes: ''
         direction: vertical
+        id: ''
+        classes: js-vertical-tabs--main
       label: Tabs
     group_agency_overall_v_b_1_:
       children:

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -392,7 +392,7 @@
             }
 
             // Attempt to get the first form element that is a child of
-            // the current tab.  If there is at least one form element that
+            // the current tab.  If there is at least one form element that has
             // the class .error, highlight this tab.
             var tab = document.getElementById(tabId.substr(1)),
               error = tab.querySelector('.js-form-item .error:not(label)');

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -379,7 +379,7 @@
         // Highlight top level tabs only.
         highlightTabs: function() {
           // Gets only the top level of vertical tab menu items.
-          var tabs = document.querySelector('.vertical-tabs__menu');
+          var tabs = document.querySelector('.js-vertical-tabs--main > .vertical-tabs > .vertical-tabs__menu');
 
           $('> .vertical-tabs__menu-item', tabs).each(function(index, menuItem) {
             try {

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -418,7 +418,7 @@
             '</div></div>');
       }
 
-      $('input#edit-validate-button').once().on('click', function(event) {
+      $('input#edit-validate-button').once('foia-validation').on('click', function(event) {
         event.preventDefault();
 
         $('.validation-overlay').removeClass('hidden');

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -369,13 +369,16 @@
        */
       $(drupalSettings.foiaUI.foiaUISettings.formID).validate({
 
-
         // Show errors using the built in defaultShowErrors() method
         // and then highlight tabs all at once.
         showErrors: function(errors) {
           this.defaultShowErrors();
-          // Gets only the top level of vertical tabs, as these will
-          // be the first .vertical-tabs__menu element in the DOM.
+          this.settings.highlightTabs();
+        },
+
+        // Highlight top level tabs only.
+        highlightTabs: function() {
+          // Gets only the top level of vertical tab menu items.
           var tabs = document.querySelector('.vertical-tabs__menu');
 
           $('> .vertical-tabs__menu-item', tabs).each(function(index, menuItem) {
@@ -403,7 +406,7 @@
             else {
               $(menuItem).removeClass('has-validation-error');
             }
-          });
+        });
         }
       });
 

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -395,7 +395,7 @@
             // the current tab.  If there is at least one form element that has
             // the class .error, highlight this tab.
             var tab = document.getElementById(tabId.substr(1)),
-              error = tab.querySelector('.js-form-item .error:not(label)');
+              error = tab.querySelector('.error:not(label)');
 
             if (error) {
               $(menuItem).addClass('has-validation-error');

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -426,7 +426,7 @@
             '</div></div>');
       }
 
-      $('input#edit-validate-button').on('click', function(event) {
+      $('input#edit-validate-button').once().on('click', function(event) {
         event.preventDefault();
 
         $('.validation-overlay').removeClass('hidden');

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -369,49 +369,41 @@
        */
       $(drupalSettings.foiaUI.foiaUISettings.formID).validate({
 
-        // Display aggregate field validation popup message.
-        invalidHandler: function(event, validator) {
-          var errors = validator.numberOfInvalids();
-          if (errors) {
-            var message = errors == 1 ? '1 field is invalid and has been highlighted.' : '' + errors + ' fields are invalid and have been highlighted.';
-            // alert(message);
-          }
-        },
 
-        // Highlight vertical tabs that contain invalid fields
-        highlight: function(element, errorClass, validClass) {
-          $(element).addClass(errorClass).removeClass(validClass);
-          var containerPaneID = $(element).parents("details.vertical-tabs__pane").last().attr('id');
-          var parentVerticalTabMenuItem = $(element).parents(".vertical-tabs").last().children('.vertical-tabs__menu').find('a[href="#' + containerPaneID + '"]').parent();
-          if(parentVerticalTabMenuItem.attr('data-invalid')) {
-            var parentVerticalTabMenuItemDataInvalid = parentVerticalTabMenuItem.attr('data-invalid');
-            if(parentVerticalTabMenuItemDataInvalid.indexOf($(element).attr('id')) === -1) {
-              parentVerticalTabMenuItemDataInvalid = parentVerticalTabMenuItem.attr('data-invalid') + ',' + $(element).attr('id');
-            }
-          }
-          else {
-            parentVerticalTabMenuItemDataInvalid = $(element).attr('id');
-          }
-          parentVerticalTabMenuItem.attr('data-invalid', parentVerticalTabMenuItemDataInvalid);
-          parentVerticalTabMenuItem.addClass('has-validation-error');
-        },
+        // Show errors using the built in defaultShowErrors() method
+        // and then highlight tabs all at once.
+        showErrors: function(errors) {
+          this.defaultShowErrors();
+          // Gets only the top level of vertical tabs, as these will
+          // be the first .vertical-tabs__menu element in the DOM.
+          var tabs = document.querySelector('.vertical-tabs__menu');
 
-        // Remove highlighting from vertical tabs when field validation passes
-        unhighlight: function(element, errorClass, validClass) {
-          $(element).removeClass(errorClass).addClass(validClass);
-          var containerPaneID = $(element).parents("details.vertical-tabs__pane").last().attr('id');
-          var parentVerticalTabMenuItem = $(element).parents(".vertical-tabs").last().children('.vertical-tabs__menu').find('a[href="#' + containerPaneID + '"]').parent();
-          var parentVerticalTabMenuItemDataInvalid = parentVerticalTabMenuItem.attr('data-invalid');
-          if( parentVerticalTabMenuItemDataInvalid && parentVerticalTabMenuItemDataInvalid.indexOf($(element).attr('id')) > -1) {
-            var dataInvalidArr = parentVerticalTabMenuItem.attr('data-invalid').split(',');
-            var index = dataInvalidArr.indexOf($(element).attr('id'));
-            if (index > -1) {
-              dataInvalidArr.splice(index, 1);
+          $('> .vertical-tabs__menu-item', tabs).each(function(index, menuItem) {
+            try {
+              var link = $('> a', menuItem).get(0),
+                  tabId = link.getAttribute('href') || false;
             }
-            var dataInvalid = dataInvalidArr.join();
-            parentVerticalTabMenuItem.attr('data-invalid', dataInvalid);
-            parentVerticalTabMenuItem.removeClass('has-validation-error');
-          }
+            catch (error) {
+              tabId = false;
+            }
+
+            if (!tabId) {
+              return;
+            }
+
+            // Attempt to get the first form element that is a child of
+            // the current tab.  If there is at least one form element that
+            // the class .error, highlight this tab.
+            var tab = document.getElementById(tabId.substr(1)),
+              error = tab.querySelector('.js-form-item .error:not(label)');
+
+            if (error) {
+              $(menuItem).addClass('has-validation-error');
+            }
+            else {
+              $(menuItem).removeClass('has-validation-error');
+            }
+          });
         }
       });
 


### PR DESCRIPTION
* Removes unhighlight and highlight functions
* Adds a showErrors method to the validator that runs the defaultShowErrors, then highlights all top level tab items at once
* Adds the `once()` method to the validate button click handler, ensuring validation runs once
* Adds a class to the form's main tab group for better targeting the top level vertical tabs in js.