### PR TITLE
FOIA-205 Include unpublished agency components - Hotfix

### DIFF
--- a/config/default/user.role.agency_administrator.yml
+++ b/config/default/user.role.agency_administrator.yml
@@ -77,6 +77,7 @@ permissions:
   - 'view all foia personnel revisions'
   - 'view all revisions'
   - 'view annual_foia_report_data revisions'
+  - 'view any unpublished agency_component content'
   - 'view any unpublished annual_foia_report_data content'
   - 'view any webform submission'
   - 'view field_complex_average_days'

--- a/config/default/user.role.agency_manager.yml
+++ b/config/default/user.role.agency_manager.yml
@@ -33,6 +33,7 @@ permissions:
   - 'view agency_component revisions'
   - 'view all revisions'
   - 'view annual_foia_report_data revisions'
+  - 'view any unpublished agency_component content'
   - 'view any unpublished annual_foia_report_data content'
   - 'view field_complex_average_days'
   - 'view field_complex_highest_days'

--- a/config/default/views.view.agency_component_by_agency.yml
+++ b/config/default/views.view.agency_component_by_agency.yml
@@ -157,44 +157,6 @@ display:
           entity_field: type
           plugin_id: bundle
           group: 1
-        status:
-          id: status
-          table: node_field_data
-          field: status
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
         field_agency_comp_abbreviation_value:
           id: field_agency_comp_abbreviation_value
           table: node__field_agency_comp_abbreviation
@@ -359,44 +321,6 @@ display:
           entity_type: node
           entity_field: type
           plugin_id: bundle
-        status_1:
-          id: status_1
-          table: node_field_data
-          field: status
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: '1'
-          group: 2
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
         field_agency_comp_abbreviation_value_1:
           id: field_agency_comp_abbreviation_value_1
           table: node__field_agency_comp_abbreviation


### PR DESCRIPTION
- Removes the "published = YES" filters on the _Agency/Component by Agency_ entity reference view.
- Grants _Agency Manager_ permission to access unpublished _Agency Component_ nodes.
- Grants _Agency Administrator_ permission to access unpublished _Agency Component_ nodes.