### PR TITLE
FOIA-202: Refresh report in IE on agency change.

### DIFF
--- a/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.libraries.yml
+++ b/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.libraries.yml
@@ -1,0 +1,7 @@
+foia_change_report_agency:
+  version: VERSION
+  js:
+    js/foia-change-report-agency.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupalSettings

--- a/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
+++ b/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
@@ -43,14 +43,20 @@ function foia_annual_data_report_form_node_annual_foia_report_data_form_alter(&$
  */
 function foia_annual_data_report_ajax_new_node(array &$form) {
 
+  // The 'change.agency' event corresponds to the event triggered in
+  // the foia_change_report_agency library that is attached to this element.
+  // This is a workaround for IE11, which does not fire the change event on
+  // this input when selecting a value from the autocomplete dropdown list.
   $form['field_agency']['widget'][0]['target_id']['#ajax'] = [
     'callback' => 'foia_annual_data_report_create_node',
-    'event' => 'change',
+    'event' => 'change.agency',
     'progress' => [
       'type' => 'throbber',
       'message' => 'Please Wait...',
     ],
   ];
+
+  $form['field_agency']['widget'][0]['target_id']['#attached']['library'][] = 'foia_annual_data_report/foia_change_report_agency';
 
 }
 
@@ -62,14 +68,19 @@ function foia_annual_data_report_ajax_new_node(array &$form) {
  */
 function foia_annual_data_report_ajax_existing_node(array &$form) {
 
+  // The 'change.agency' event corresponds to the event triggered in
+  // the foia_change_report_agency library that is attached to this element.
+  // This is a workaround for IE11, which does not fire the change event on
+  // this input when selecting a value from the autocomplete dropdown list.
   $form['field_agency']['widget'][0]['target_id']['#ajax'] = [
     'callback' => 'foia_annual_data_report_refresh',
-    'event' => 'change',
+    'event' => 'change.agency',
     'progress' => [
       'type' => 'throbber',
       'message' => 'Please Wait...',
     ],
   ];
+  $form['field_agency']['widget'][0]['target_id']['#attached']['library'][] = 'foia_annual_data_report/foia_change_report_agency';
 
 }
 

--- a/docroot/modules/custom/foia_annual_data_report/js/foia-change-report-agency.js
+++ b/docroot/modules/custom/foia_annual_data_report/js/foia-change-report-agency.js
@@ -1,0 +1,24 @@
+(function ($, drupalSettings) {
+  Drupal.behaviors.foia_change_report_agency = {
+    attach: function attach() {
+      this.triggerNodeRefreshOnUpdate();
+    },
+
+    /**
+     * Triggers the change.agency event which is listened for by the form element's ajax handler.
+     *
+     * The change event doesn't fire for the autocomplete field in IE11.  To work around this,
+     * this method listens for the blur event on the field, checks if the field value has
+     * changed, and triggers a refresh in all browsers if it has.
+     */
+    triggerNodeRefreshOnUpdate: function() {
+      drupalSettings.foiaReportAgencyInitialValue = $('#edit-field-agency-0-target-id').val();
+
+      $('#edit-field-agency-0-target-id').once('foia-trigger-agency-change').blur(function(event) {
+        if ($(this).val() !== drupalSettings.foiaReportAgencyInitialValue) {
+          $('#edit-field-agency-0-target-id').trigger('change.agency');
+        }
+      });
+    }
+  }
+})(jQuery, drupalSettings);

--- a/docroot/modules/custom/foia_annual_data_report/js/foia-change-report-agency.js
+++ b/docroot/modules/custom/foia_annual_data_report/js/foia-change-report-agency.js
@@ -10,6 +10,9 @@
      * The change event doesn't fire for the autocomplete field in IE11.  To work around this,
      * this method listens for the blur event on the field, checks if the field value has
      * changed, and triggers a refresh in all browsers if it has.
+     *
+     * @see foia_annual_data_report_ajax_existing_node()
+     * @see foia_annual_data_report_ajax_new_node()
      */
     triggerNodeRefreshOnUpdate: function() {
       drupalSettings.foiaReportAgencyInitialValue = $('#edit-field-agency-0-target-id').val();


### PR DESCRIPTION
The change event was not firing in IE11 when a new value for
field_agency was selected from the autocomplete drop down.  To work
around this, listen for a blur event on that field and fire a custom
change event if the value has changed.