### PR TITLE
FOIA-197: Don't disable save on report node forms.

### DIFF
--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -410,9 +410,6 @@
         }
       });
 
-      // Disable Submit button until Validate button is clicked.
-      $('input#edit-submit').prop('disabled', true);
-
       if ($('#validation-overlay').length === 0) {
         $('body').append('<div id="validation-overlay"' +
             ' class="validation-overlay hidden">' +
@@ -442,9 +439,6 @@
           // Drupal's default empty drop-down value to avoid "An illegal
           // choice has been detected" error in that scenario.
           $("select > option[value='']").val('_none');
-
-          // Enable form Save button
-          $('input#edit-submit').prop('disabled', false);
         }, 100);
       });
 


### PR DESCRIPTION
Remove the requirement that the Validate button is clicked in order to
save an annual report form.  This fixes the issue where the save button
is disabled again if the form autosaves or a paragraph component is
added.