### PR TITLE
Foia 145 automatic entity label

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "drupal/acquia_connector": "^1.5.0",
         "drupal/acquia_purge": "^1.0-beta3",
         "drupal/address": "~1.0",
+        "drupal/auto_entitylabel": "^3.0@beta",
         "drupal/autologout": "^1.0",
         "drupal/autosave_form": "^1.0",
         "drupal/cog": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01e9703e94e8943e774002be284908ff",
+    "content-hash": "6aeb0a2815ca4b0f5c77c17e66b34b02",
     "packages": [
         {
             "name": "acquia/blt",
@@ -3433,6 +3433,74 @@
             "homepage": "http://drupal.org/project/address",
             "support": {
                 "source": "https://git.drupalcode.org/project/address"
+            }
+        },
+        {
+            "name": "drupal/auto_entitylabel",
+            "version": "3.0.0-beta2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/auto_entitylabel.git",
+                "reference": "8.x-3.0-beta2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/auto_entitylabel-8.x-3.0-beta2.zip",
+                "reference": "8.x-3.0-beta2",
+                "shasum": "b1fcf53f57147bbe445d5ff97e42c5c1a2a2718a"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-3.0-beta2",
+                    "datestamp": "1570745586",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Pravin Ajaaz",
+                    "homepage": "https://www.drupal.org/user/2910049"
+                },
+                {
+                    "name": "RenatoG",
+                    "homepage": "https://www.drupal.org/user/3326031"
+                },
+                {
+                    "name": "bforchhammer",
+                    "homepage": "https://www.drupal.org/user/216396"
+                },
+                {
+                    "name": "colan",
+                    "homepage": "https://www.drupal.org/user/58704"
+                },
+                {
+                    "name": "diqidoq",
+                    "homepage": "https://www.drupal.org/user/1001934"
+                },
+                {
+                    "name": "purushotam.rai",
+                    "homepage": "https://www.drupal.org/user/3193859"
+                }
+            ],
+            "description": "Allows hiding of entity label fields and automatic label creation.",
+            "homepage": "https://www.drupal.org/project/auto_entitylabel",
+            "support": {
+                "source": "https://git.drupalcode.org/project/auto_entitylabel",
+                "issues": "https://www.drupal.org/project/issues/auto_entitylabel"
             }
         },
         {
@@ -18892,6 +18960,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "drupal/auto_entitylabel": 10,
         "drupal/feeds": 15,
         "drupal/feeds_ex": 15,
         "drupal/field_group": 5,

--- a/config/default/auto_entitylabel.settings.node.annual_foia_report_data.yml
+++ b/config/default/auto_entitylabel.settings.node.annual_foia_report_data.yml
@@ -1,5 +1,5 @@
-status: 2
-pattern: '[node:field_agency:entity:field_agency_abbreviation] - [current-date:html_year] - Annual FOIA Report'
+status: 1
+pattern: '[node:field_agency:entity:field_agency_abbreviation] - [node:field_foia_annual_report_yr] - Annual FOIA Report'
 escape: false
 dependencies:
   config:

--- a/config/default/auto_entitylabel.settings.node.annual_foia_report_data.yml
+++ b/config/default/auto_entitylabel.settings.node.annual_foia_report_data.yml
@@ -1,0 +1,6 @@
+status: 2
+pattern: '[node:field_agency:entity:field_agency_abbreviation] - [current-date:html_year] - Annual FOIA Report'
+escape: false
+dependencies:
+  config:
+    - node.type.annual_foia_report_data

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -1,5 +1,6 @@
 module:
   address: 0
+  auto_entitylabel: 0
   autologout: 0
   autosave_form: 0
   basic_auth: 0

--- a/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
+++ b/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
@@ -100,14 +100,8 @@ function foia_annual_data_report_create_node(array $form, FormStateInterface
 
   $response = new AjaxResponse();
 
-  // Set a temporary title, in case they have not.
-  $report_title = $form_state->getValue('title')[0]['value'] ?
-  $form_state->getValue('title')[0]['value'] :
-  'Agency Report ' . date('Y-m-d');
-
   $node = \Drupal::entityTypeManager()->getStorage('node')->create([
     'type' => 'annual_foia_report_data',
-    'title' => $report_title,
     'field_agency' => $form_state->getValue('field_agency'),
   ]);
   $node->save();

--- a/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
+++ b/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
@@ -18,6 +18,7 @@ use Drupal\Core\Ajax\RedirectCommand;
 function foia_annual_data_report_form_node_annual_foia_report_data_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Add the AJAX save callbacks.
   foia_annual_data_report_ajax_existing_node($form);
+  foia_annual_data_report_set_default_report_year($form);
 
   // Force a submit function to increase memory limit before core's submit.
   foreach (array_keys($form['actions']) as $action) {

--- a/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
+++ b/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
@@ -32,10 +32,7 @@ function foia_annual_data_report_form_node_annual_foia_report_data_edit_form_alt
  * Implements hook_form_form_id_alter().
  */
 function foia_annual_data_report_form_node_annual_foia_report_data_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  // Set the FOIA annual report year default to the current year.  This allows
-  // the auto_entitylabel module to rely on the field_foia_annual_report_yr
-  // value when setting the title.
-  $form['field_foia_annual_report_yr']['widget'][0]['value']['#default_value'] = (int) date('Y');
+  foia_annual_data_report_set_default_report_year($form);
   foia_annual_data_report_ajax_new_node($form);
 }
 
@@ -185,6 +182,22 @@ function foia_annual_data_report_node_load($entities) {
         break;
       }
     }
+  }
+}
+
+/**
+ * Set the FOIA annual report year field's default value to the current year.
+ *
+ * This allows the auto_entitylabel module to rely on the
+ * field_foia_annual_report_yr value when setting the title.
+ *
+ * @param array $form
+ *   The annual_foia_report_data node add or edit form array.
+ */
+function foia_annual_data_report_set_default_report_year(array &$form) {
+  $default_value = $form['field_foia_annual_report_yr']['widget'][0]['value']['#default_value'] ?? FALSE;
+  if (!$default_value) {
+    $form['field_foia_annual_report_yr']['widget'][0]['value']['#default_value'] = date('Y');
   }
 }
 

--- a/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
+++ b/docroot/modules/custom/foia_annual_data_report/foia_annual_data_report.module
@@ -32,6 +32,10 @@ function foia_annual_data_report_form_node_annual_foia_report_data_edit_form_alt
  * Implements hook_form_form_id_alter().
  */
 function foia_annual_data_report_form_node_annual_foia_report_data_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Set the FOIA annual report year default to the current year.  This allows
+  // the auto_entitylabel module to rely on the field_foia_annual_report_yr
+  // value when setting the title.
+  $form['field_foia_annual_report_yr']['widget'][0]['value']['#default_value'] = (int) date('Y');
   foia_annual_data_report_ajax_new_node($form);
 }
 
@@ -103,6 +107,7 @@ function foia_annual_data_report_create_node(array $form, FormStateInterface
   $node = \Drupal::entityTypeManager()->getStorage('node')->create([
     'type' => 'annual_foia_report_data',
     'field_agency' => $form_state->getValue('field_agency'),
+    'field_foia_annual_report_yr' => $form_state->getValue('field_foia_annual_report_yr'),
   ]);
   $node->save();
 

--- a/tests/behat/features/Administrator.feature
+++ b/tests/behat/features/Administrator.feature
@@ -225,7 +225,6 @@ Feature: Agency Administrator role
       | test  |DOJ                      | description |plain_text| en       |
     When I am logged in as a user with the 'Agency Administrator' role
     And I am on "/node/add/annual_foia_report_data"
-    And for 'Title' I enter 'A Test Report'
     And for 'Agency' I enter 'test'
     And I select "Draft" from "Save as"
     When I press the 'Save' button

--- a/tests/behat/features/AnnualFOIAReportData.feature
+++ b/tests/behat/features/AnnualFOIAReportData.feature
@@ -16,13 +16,12 @@ Feature: Annual FOIA Report Data Feature
   Scenario: Create an Annual FOIA Report Data node.
     Given I am logged in as a user with the 'Administrator' role
     And I am at 'node/add/annual_foia_report_data'
-    And for 'Title' I enter '2019 Test Agency 1 Annual FOIA Report'
     And for 'Agency' I enter 'Federal Testing Agency'
     And for 'FOIA Annual Report Year' I enter '2019'
     And for 'Date Prepared' I enter '08/22/2019'
     When I press the 'Save' button
     Then I should see the following success messages:
-      | Annual FOIA Report Data 2019 Test Agency 1 Annual FOIA Report has been created. |
+      | FTA - 2019 - Annual FOIA Report has been created. |
 
   @api
   Scenario: Edit an Annual FOIA Report Data node Section IV Exemption 3 Statutes.
@@ -32,7 +31,7 @@ Feature: Annual FOIA Report Data Feature
     And I press the 'Save' button
     Then I should see the following success messages:
       | Annual FOIA Report Data 2019 Test Agency 1 Annual FOIA Report has been updated. |
-    
+
 
   @api
   Scenario: Edit an Annual FOIA Report Data node Section V.A. FOIA REQUESTS.


### PR DESCRIPTION
* Makes annual report node titles uneditable by users
* Automatically titles annual report nodes as `{{Agency Term Abbreviation}} - {{Annual Report Year Field}} - Annual FOIA Report`
* Updates the title if field data changes.
* Uses the Agency term's abbreviation field since the node's agency field is required (as opposed to the node's Agency Abbreviation field).
* Sets the default value of the nodes FOIA Annual Report Year field to the current year, if a value does not already exist.
* Removes filling out the title in the `Administrator.feature` behat test scenario `Agency Administrator can save Annual FOIA Reports in all workflow
  states`
* Removes filling out the title in the `AnnualFOIAReportData.feature` behat test scenario `Create an Annual FOIA Report Data node.` and checks that the title set adheres to the autolabel pattern.