### PR TITLE
FOIA-175: Output "N/A" to auto-calculated field when all source fields are "N/A"

### DIFF
--- a/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
+++ b/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
@@ -52,7 +52,6 @@
         var ops = {
           '<': function(a, b) { return a < b },
           '>': function(a, b) { return a > b },
-          '+': function(a, b) { return a + b },
         }
         var fields = $("input[id^='" + componentId + "']").filter("input[name*='" + componentFieldName + "']");
         fields.each(function() {
@@ -61,7 +60,7 @@
             var isOverallNA = true;
             fields.each(function () {
               value = $(this).val();
-              if(String(value).toLowerCase() != 'n/a') {
+              if (String(value).toLowerCase() != 'n/a') {
                 isOverallNA = false;
                 if (value != '' && value !== null && (output == null || output == "n/a")) {
                   // Set output for the first valid value.
@@ -74,11 +73,11 @@
               }
             });
             // Clear overall value if output is "NaN".
-            if(output !== output) {
+            if (output !== output) {
               output = '';
             }
             // Set overall value to "N/A" if all fields are "N/A".
-            else if(isOverallNA) {
+            else if (isOverallNA) {
               output = 'N/A';
             }
             $('#' + event.data.overallFieldID).val(output);
@@ -163,9 +162,6 @@
       calcOverall('edit-field-proc-req-viib', 'field_exp_low', 'edit-field-overall-viib-exp-low-0-value', '<');
       // Fields from section VII.B. to calculate Highest Number of Days (expedited).
       calcOverall('edit-field-proc-req-viib', 'field_exp_high', 'edit-field-overall-viib-exp-high-0-value', '>');
-
-      // Fields from section VIII.A. to calculate Overall Number Adjudicated Within Ten Calendar Days.
-      calcOverall('edit-field-req-viiia', 'field_num_jud_w10', 'edit-field-overall-viiia-num-jud-w10-0-value', '+');
 
       // Section V A automatically calculate field_req_pend_end_yr.
       // req_pend_start_yr + req_received_yr - req_processed_yr = req_pend_end_yr

--- a/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
+++ b/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
@@ -58,24 +58,30 @@
         fields.each(function() {
           $(this).once('advCalcOverall').on('change', {overallFieldID: overallFieldID, operator: operator}, function(event) {
             var output = null;
+            var isOverallNA = true;
             fields.each(function () {
               value = $(this).val();
-              if(value != '' && String(value).toLowerCase() != 'n/a') {
-                if (output == null && value !== null) {
+              if(String(value).toLowerCase() != 'n/a') {
+                isOverallNA = false;
+                if (value != '' && value !== null && (output == null || output == "n/a")) {
+                  // Set output for the first valid value.
                   output = displayLessThan(specialNumber(value));
                 }
-                else if(value != undefined && ops[event.data.operator](specialNumber(value), specialNumber(output))) {
+                else if(value != '' && value != undefined && ops[event.data.operator](specialNumber(value), specialNumber(output))) {
+                  // Override output if operation criterion is met.
                   output = displayLessThan(specialNumber(value));
                 }
               }
             });
-            // Clear overall value if output is "NaN"
+            // Clear overall value if output is "NaN".
             if(output !== output) {
-              $('#' + event.data.overallFieldID).val('');
+              output = '';
             }
-            else {
-              $('#' + event.data.overallFieldID).val(output);
+            // Set overall value to "N/A" if all fields are "N/A".
+            else if(isOverallNA) {
+              output = 'N/A';
             }
+            $('#' + event.data.overallFieldID).val(output);
           });
         });
       }

--- a/docroot/modules/custom/foia_autocalc/js/autocalc-field.js
+++ b/docroot/modules/custom/foia_autocalc/js/autocalc-field.js
@@ -20,12 +20,20 @@
   function calculateField(fieldName, fieldSettings) {
     var totalValues = {};
     var idSelector = '';
+    var isTotalNA = true;
 
     fieldSettings.forEach(function (fieldSetting) {
       $(convertToFieldSelector(fieldSetting) + ' input').each(function() {
+        var value = $(this).val();
         var selectedValue = 0;
-        if (isNumeric($(this).val())) {
-          selectedValue = Number($(this).val());
+        if (String(value).toLowerCase() === "n/a") {
+          var selectedValue = null;
+        }
+        else {
+          isTotalNA = false;
+          if ( isNumeric(value) ) {
+            selectedValue = Number($(this).val());
+          }
         }
 
         // Get the selector for this field.
@@ -39,7 +47,9 @@
 
         // Add value to the selector.
         if (totalValues.hasOwnProperty(idSelector)) {
-          totalValues[idSelector] += selectedValue;
+          if(selectedValue !== null) {
+            totalValues[idSelector] += selectedValue;
+          }
         }
         else {
           totalValues[idSelector] = selectedValue;
@@ -48,6 +58,10 @@
     });
 
     Object.keys(totalValues).forEach(function (selector) {
+      // Set overall value to "N/A" if all fields are "N/A".
+      if(isTotalNA) {
+        totalValues[selector] = "N/A";
+      }
       if (selector == 'all') {
         $(convertToFieldSelector({ field: fieldName }) + ' input').val(totalValues[selector]).trigger('change');
       }


### PR DESCRIPTION
-  Output overall as "N/A" on V1.C.4, VII.A, VII.B, VII.D. when all source fields  are "N/A".
- Remove duplicate advanced auto-calculation for _VIII.A Agency Overall Number Adjudicated Within Ten Calendar Days_. It is now handled only by existing `foia_autocalc` configuration.
- Add support to `foia_autocalc` module to treat "N/A" values as Null.
- Add support to `foia_autocalc` module to output total as "N/A" when all source field values are "N/A".