### PR TITLE
FOIA-172: Queue report uploads.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "drupal/paragraphs": "^1.8",
         "drupal/password_policy": "^3.0@alpha",
         "drupal/qa_accounts": "^1.0.0-alpha1",
+        "drupal/queue_ui": "^2.0",
         "drupal/restui": "^1.15",
         "drupal/roleassign": "^1.0@alpha",
         "drupal/rules": "^3.0@alpha",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6aeb0a2815ca4b0f5c77c17e66b34b02",
+    "content-hash": "331d0828474d3a858e2fd85bf7af182e",
     "packages": [
         {
             "name": "acquia/blt",
@@ -8704,6 +8704,69 @@
             "homepage": "https://www.drupal.org/project/qa_accounts",
             "support": {
                 "source": "https://git.drupalcode.org/project/qa_accounts"
+            }
+        },
+        {
+            "name": "drupal/queue_ui",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/queue_ui.git",
+                "reference": "8.x-2.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/queue_ui-8.x-2.0.zip",
+                "reference": "8.x-2.0",
+                "shasum": "7edf7715d7ca5d255fc3ea86aff27997617af8ea"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-2.0",
+                    "datestamp": "1530874421",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "bceyssens",
+                    "homepage": "https://www.drupal.org/user/2743951"
+                },
+                {
+                    "name": "coltrane",
+                    "homepage": "https://www.drupal.org/user/91990"
+                },
+                {
+                    "name": "floretan",
+                    "homepage": "https://www.drupal.org/user/66163"
+                },
+                {
+                    "name": "jochemh",
+                    "homepage": "https://www.drupal.org/user/2811585"
+                },
+                {
+                    "name": "tsphethean",
+                    "homepage": "https://www.drupal.org/user/881620"
+                }
+            ],
+            "description": "Interface and manager for Drupal queues.",
+            "homepage": "https://www.drupal.org/project/queue_ui",
+            "support": {
+                "source": "https://git.drupalcode.org/project/queue_ui"
             }
         },
         {

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -99,6 +99,7 @@ module:
   password_policy_history: 0
   password_policy_length: 0
   path: 0
+  queue_ui: 0
   quickedit: 0
   rdf: 0
   rest: 0

--- a/config/default/lightning_core.versions.yml
+++ b/config/default/lightning_core.versions.yml
@@ -98,6 +98,7 @@ password_policy_character_types: 3.0.0-alpha4
 password_policy_history: 3.0.0-alpha4
 password_policy_length: 3.0.0-alpha4
 path: 8.4.5
+queue_ui: 2.0.0
 quickedit: 8.4.5
 rdf: 8.4.5
 rest: 8.4.5

--- a/config/default/migrate_plus.migration.component.yml
+++ b/config/default/migrate_plus.migration.component.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_iv_statutes.yml
+++ b/config/default/migrate_plus.migration.component_iv_statutes.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_iv_statutes
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_ix_personnel.yml
+++ b/config/default/migrate_plus.migration.component_ix_personnel.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_ix_personnel
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_va_requests.yml
+++ b/config/default/migrate_plus.migration.component_va_requests.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_va_requests
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_vb1_requests.yml
+++ b/config/default/migrate_plus.migration.component_vb1_requests.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_vb1_requests
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_vb2_requests.yml
+++ b/config/default/migrate_plus.migration.component_vb2_requests.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_vb2_requests
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_vb3_requests.yml
+++ b/config/default/migrate_plus.migration.component_vb3_requests.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_vb3_requests
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_via_disposition.yml
+++ b/config/default/migrate_plus.migration.component_via_disposition.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_via_disposition
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_vib_disposition.yml
+++ b/config/default/migrate_plus.migration.component_vib_disposition.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_vib_disposition
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_vic1_applied_exemptions.yml
+++ b/config/default/migrate_plus.migration.component_vic1_applied_exemptions.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_vic1_applied_exemptions
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_vic2_nonexemption_denial.yml
+++ b/config/default/migrate_plus.migration.component_vic2_nonexemption_denial.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_vic2_nonexemption_denial
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_vic3_other_denial.yml
+++ b/config/default/migrate_plus.migration.component_vic3_other_denial.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_vic3_other_denial
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_vic4_response_time.yml
+++ b/config/default/migrate_plus.migration.component_vic4_response_time.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_vic4_response_time
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_vic5_oldest_pending.yml
+++ b/config/default/migrate_plus.migration.component_vic5_oldest_pending.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_vic5_oldest_pending
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_viia_processed_requests.yml
+++ b/config/default/migrate_plus.migration.component_viia_processed_requests.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_viia_processed_requests
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_viib_processed_requests.yml
+++ b/config/default/migrate_plus.migration.component_viib_processed_requests.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_viib_processed_requests
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_viic1_simple_response.yml
+++ b/config/default/migrate_plus.migration.component_viic1_simple_response.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_viic1_simple_response
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_viic2_complex_response.yml
+++ b/config/default/migrate_plus.migration.component_viic2_complex_response.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_viic2_complex_response
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_viic3_expedited_response.yml
+++ b/config/default/migrate_plus.migration.component_viic3_expedited_response.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_viic3_expedited_response
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_viid_pending_requests.yml
+++ b/config/default/migrate_plus.migration.component_viid_pending_requests.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_viid_pending_requests
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_viie_oldest_pending.yml
+++ b/config/default/migrate_plus.migration.component_viie_oldest_pending.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_viie_oldest_pending
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_viiia_expedited_processing.yml
+++ b/config/default/migrate_plus.migration.component_viiia_expedited_processing.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_viiia_expedited_processing
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_viiib_fee_waiver.yml
+++ b/config/default/migrate_plus.migration.component_viiib_fee_waiver.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_viiib_fee_waiver
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_x_fees.yml
+++ b/config/default/migrate_plus.migration.component_x_fees.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_x_fees
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_xia_subsection_c.yml
+++ b/config/default/migrate_plus.migration.component_xia_subsection_c.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_xia_subsection_c
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_xib_subsection_a2.yml
+++ b/config/default/migrate_plus.migration.component_xib_subsection_a2.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_xib_subsection_a2
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_xiia.yml
+++ b/config/default/migrate_plus.migration.component_xiia.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_xiia
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_xiib.yml
+++ b/config/default/migrate_plus.migration.component_xiib.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_xiib
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_xiic.yml
+++ b/config/default/migrate_plus.migration.component_xiic.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_xiic
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_xiid1.yml
+++ b/config/default/migrate_plus.migration.component_xiid1.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_xiid1
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_xiid2.yml
+++ b/config/default/migrate_plus.migration.component_xiid2.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_xiid2
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_xiie1.yml
+++ b/config/default/migrate_plus.migration.component_xiie1.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_xiie1
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.component_xiie2.yml
+++ b/config/default/migrate_plus.migration.component_xiie2.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_xiie2
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.foia_agency_report.yml
+++ b/config/default/migrate_plus.migration.foia_agency_report.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_agency_report
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags:

--- a/config/default/migrate_plus.migration.foia_iv_details.yml
+++ b/config/default/migrate_plus.migration.foia_iv_details.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_iv_details
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_iv_statute.yml
+++ b/config/default/migrate_plus.migration.foia_iv_statute.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_iv_statute
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_ix_personnel.yml
+++ b/config/default/migrate_plus.migration.foia_ix_personnel.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_ix_personnel
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_va_requests.yml
+++ b/config/default/migrate_plus.migration.foia_va_requests.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_va_requests
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_vb1_requests.yml
+++ b/config/default/migrate_plus.migration.foia_vb1_requests.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_vb1_requests
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_vb2.yml
+++ b/config/default/migrate_plus.migration.foia_vb2.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_vb2
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_vb2_other.yml
+++ b/config/default/migrate_plus.migration.foia_vb2_other.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_vb2_other
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_vb3_requests.yml
+++ b/config/default/migrate_plus.migration.foia_vb3_requests.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_vb3_requests
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_via_disposition.yml
+++ b/config/default/migrate_plus.migration.foia_via_disposition.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_via_disposition
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_vib_disposition.yml
+++ b/config/default/migrate_plus.migration.foia_vib_disposition.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_vib_disposition
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_vic1_applied_exemptions.yml
+++ b/config/default/migrate_plus.migration.foia_vic1_applied_exemptions.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_vic1_applied_exemptions
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_vic2_nonexemption_denial.yml
+++ b/config/default/migrate_plus.migration.foia_vic2_nonexemption_denial.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_vic2_nonexemption_denial
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_vic3.yml
+++ b/config/default/migrate_plus.migration.foia_vic3.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_vic3
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_vic3_other.yml
+++ b/config/default/migrate_plus.migration.foia_vic3_other.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_vic3_other
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_vic4_response_time.yml
+++ b/config/default/migrate_plus.migration.foia_vic4_response_time.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_vic4_response_time
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_vic5_oldest_pending.yml
+++ b/config/default/migrate_plus.migration.foia_vic5_oldest_pending.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_vic5_oldest_pending
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_viia_processed_requests.yml
+++ b/config/default/migrate_plus.migration.foia_viia_processed_requests.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_viia_processed_requests
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_viib_processed_requests.yml
+++ b/config/default/migrate_plus.migration.foia_viib_processed_requests.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_viib_processed_requests
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_viic1_simple_response.yml
+++ b/config/default/migrate_plus.migration.foia_viic1_simple_response.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_viic1_simple_response
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_viic2_complex_response.yml
+++ b/config/default/migrate_plus.migration.foia_viic2_complex_response.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_viic2_complex_response
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_viic3_expedited_response.yml
+++ b/config/default/migrate_plus.migration.foia_viic3_expedited_response.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_viic3_expedited_response
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_viid_pending_requests.yml
+++ b/config/default/migrate_plus.migration.foia_viid_pending_requests.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_viid_pending_requests
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_viie_oldest_pending.yml
+++ b/config/default/migrate_plus.migration.foia_viie_oldest_pending.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_viie_oldest_pending
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_viiia_expedited_processing.yml
+++ b/config/default/migrate_plus.migration.foia_viiia_expedited_processing.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_viiia_expedited_processing
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_viiib_fee_waiver.yml
+++ b/config/default/migrate_plus.migration.foia_viiib_fee_waiver.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_viiib_fee_waiver
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_x_fees.yml
+++ b/config/default/migrate_plus.migration.foia_x_fees.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_x_fees
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_xia_subsection_c.yml
+++ b/config/default/migrate_plus.migration.foia_xia_subsection_c.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_xia_subsection_c
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_xib_subsection_a2.yml
+++ b/config/default/migrate_plus.migration.foia_xib_subsection_a2.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_xib_subsection_a2
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_xiia.yml
+++ b/config/default/migrate_plus.migration.foia_xiia.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_xiia
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_xiib.yml
+++ b/config/default/migrate_plus.migration.foia_xiib.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_xiib
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_xiic.yml
+++ b/config/default/migrate_plus.migration.foia_xiic.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_xiic
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_xiid1.yml
+++ b/config/default/migrate_plus.migration.foia_xiid1.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_xiid1
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_xiid2.yml
+++ b/config/default/migrate_plus.migration.foia_xiid2.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_xiid2
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_xiie1.yml
+++ b/config/default/migrate_plus.migration.foia_xiie1.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_xiie1
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/config/default/migrate_plus.migration.foia_xiie2.yml
+++ b/config/default/migrate_plus.migration.foia_xiie2.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: foia_xiie2
-class: null
+class: \Drupal\foia_upload_xml\Plugin\migrate\FoiaUploadXmlMigration
 field_plugin_method: null
 cck_plugin_method: null
 migration_tags: null

--- a/docroot/modules/custom/foia_upload_xml/foia_upload_xml.batch.inc
+++ b/docroot/modules/custom/foia_upload_xml/foia_upload_xml.batch.inc
@@ -5,6 +5,8 @@
  * Helper functions called by the Batch API.
  */
 
+use Drupal\file\FileInterface;
+
 /**
  * Executes Migration's Import with Batch context.
  *
@@ -15,9 +17,9 @@
  *
  * @throws \Drupal\migrate\MigrateException
  */
-function foia_upload_xml_execute_migration($migration_list_item, array &$context) {
+function foia_upload_xml_execute_migration($migration_list_item, FileInterface $sourceFile, array &$context) {
   $batch_import = \Drupal::service('foia_upload_xml.batch_import');
-  $batch_import->executeMigration($migration_list_item, $context);
+  $batch_import->executeMigration($migration_list_item, $sourceFile, $context);
 }
 
 /**

--- a/docroot/modules/custom/foia_upload_xml/foia_upload_xml.services.yml
+++ b/docroot/modules/custom/foia_upload_xml/foia_upload_xml.services.yml
@@ -5,3 +5,6 @@ services:
   foia_upload_xml.report_upload_validator:
     class: Drupal\foia_upload_xml\ReportUploadValidator
     arguments: ['@plugin.manager.migrate_plus.data_parser', '@entity_type.manager']
+  foia_upload_xml.migrations_processor:
+    class: Drupal\foia_upload_xml\FoiaUploadXmlMigrationsProcessor
+    arguments: ['@plugin.manager.migration']

--- a/docroot/modules/custom/foia_upload_xml/foia_upload_xml.services.yml
+++ b/docroot/modules/custom/foia_upload_xml/foia_upload_xml.services.yml
@@ -8,3 +8,6 @@ services:
   foia_upload_xml.migrations_processor:
     class: Drupal\foia_upload_xml\FoiaUploadXmlMigrationsProcessor
     arguments: ['@plugin.manager.migration']
+  foia_upload_xml.report_parser:
+    class: Drupal\foia_upload_xml\FoiaUploadXmlReportParser
+    arguments: ['@plugin.manager.migrate_plus.data_parser', '@entity_type.manager']

--- a/docroot/modules/custom/foia_upload_xml/foia_upload_xml.services.yml
+++ b/docroot/modules/custom/foia_upload_xml/foia_upload_xml.services.yml
@@ -1,7 +1,7 @@
 services:
   foia_upload_xml.batch_import:
     class: Drupal\foia_upload_xml\FoiaUploadXmlBatchImport
-    arguments: ['@messenger', '@plugin.manager.migration', '@current_user']
+    arguments: ['@messenger', '@foia_upload_xml.migrations_processor', '@current_user']
   foia_upload_xml.report_upload_validator:
     class: Drupal\foia_upload_xml\ReportUploadValidator
     arguments: ['@plugin.manager.migrate_plus.data_parser', '@entity_type.manager']

--- a/docroot/modules/custom/foia_upload_xml/foia_upload_xml.services.yml
+++ b/docroot/modules/custom/foia_upload_xml/foia_upload_xml.services.yml
@@ -4,7 +4,7 @@ services:
     arguments: ['@messenger', '@foia_upload_xml.migrations_processor', '@current_user']
   foia_upload_xml.report_upload_validator:
     class: Drupal\foia_upload_xml\ReportUploadValidator
-    arguments: ['@plugin.manager.migrate_plus.data_parser', '@entity_type.manager']
+    arguments: ['@foia_upload_xml.report_parser', '@entity_type.manager', '@database']
   foia_upload_xml.migrations_processor:
     class: Drupal\foia_upload_xml\FoiaUploadXmlMigrationsProcessor
     arguments: ['@plugin.manager.migration']

--- a/docroot/modules/custom/foia_upload_xml/src/FoiaUploadXmlBatchImport.php
+++ b/docroot/modules/custom/foia_upload_xml/src/FoiaUploadXmlBatchImport.php
@@ -19,7 +19,7 @@ class FoiaUploadXmlBatchImport {
   /**
    * The messenger service.
    *
-   * @var Drupal\Core\Messenger\MessengerInterface
+   * @var \Drupal\Core\Messenger\MessengerInterface
    */
   protected $messenger;
 
@@ -33,18 +33,18 @@ class FoiaUploadXmlBatchImport {
   /**
    * The current user object.
    *
-   * @var Drupal\Core\Session\AccountInterface
+   * @var \Drupal\Core\Session\AccountInterface
    */
   protected $user;
 
   /**
    * Creates a FoiaUploadXmlBatchImport object.
    *
-   * @param Drupal\Core\Messenger\MessengerInterface $messenger
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   The messenger service.
    * @param \Drupal\foia_upload_xml\FoiaUploadXmlMigrationsProcessor $foiaUploadXmlMigrationsProcessor
    *   A class to configure and process report migrations.
-   * @param Drupal\Core\Session\AccountInterface $user
+   * @param \Drupal\Core\Session\AccountInterface $user
    *   The user to be used as the owner of the imported node.
    */
   public function __construct(MessengerInterface $messenger, FoiaUploadXmlMigrationsProcessor $foiaUploadXmlMigrationsProcessor, AccountInterface $user) {

--- a/docroot/modules/custom/foia_upload_xml/src/FoiaUploadXmlMigrationsProcessor.php
+++ b/docroot/modules/custom/foia_upload_xml/src/FoiaUploadXmlMigrationsProcessor.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Drupal\foia_upload_xml;
+
+use Drupal\file\FileInterface;
+use Drupal\migrate\MigrateMessage;
+use Drupal\migrate_plus\Entity\Migration;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\migrate_tools\MigrateExecutable;
+use Drupal\migrate\MigrateMessageInterface;
+use Drupal\migrate\Plugin\MigrationPluginManager;
+
+/**
+ * Configures and runs migrations for the batch processor or import worker.
+ *
+ * @package Drupal\foia_upload_xml
+ */
+class FoiaUploadXmlMigrationsProcessor {
+
+  /**
+   * The migration plugin manager.
+   *
+   * @var \Drupal\migrate\Plugin\MigrationPluginManager
+   */
+  protected $migrationPluginManager;
+
+  /**
+   * The migration message.
+   *
+   * @var \Drupal\migrate\MigrateMessageInterface
+   */
+  protected $migrateMessage;
+
+  /**
+   * Configuration overrides if processing all migrations.
+   *
+   * @var array
+   */
+  protected $sourceOverrides;
+
+  /**
+   * FoiaUploadXmlMigrationsProcessor constructor.
+   *
+   * @param \Drupal\migrate\Plugin\MigrationPluginManager $migrationPluginManager
+   *   The migration plugin manager.
+   */
+  public function __construct(MigrationPluginManager $migrationPluginManager) {
+    $this->migrationPluginManager = $migrationPluginManager;
+    $this->migrateMessage = new MigrateMessage();
+    $this->sourceOverrides = [];
+  }
+
+  /**
+   * Process a single migration.
+   *
+   * @param string $migration_id
+   *   The migration id to be processed.
+   * @param array $configuration
+   *   Configuration to pass to the migrationPluginManager when creating the
+   *   migration instance.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   * @throws \Drupal\migrate\MigrateException
+   */
+  public function process($migration_id, array $configuration) {
+    /** @var \Drupal\migrate\Plugin\Migration $migration */
+    $migration = $this->migrationPluginManager->createInstance($migration_id, $configuration);
+    $migration->getIdMap()->prepareUpdate();
+    $executable = new MigrateExecutable($migration, new MigrateMessage());
+    $executable->import();
+  }
+
+  /**
+   * Process all the migrations at once.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   * @throws \Drupal\migrate\MigrateException
+   */
+  public function processAll() {
+    foreach ($this->getMigrationsList() as $migration_id) {
+      $this->process($migration_id, $this->sourceOverrides);
+    }
+  }
+
+  /**
+   * Load the migrations, set them to use the source file's path, and save them.
+   *
+   * @param \Drupal\file\FileInterface $file
+   *   The current migration's source file.
+   *
+   * @return $this
+   *   The current object, for chaining.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function setSourceFile(FileInterface $file) {
+    foreach ($this->getMigrationsList() as $migration_list_item) {
+      $migration = Migration::load($migration_list_item);
+      $source = $migration->get('source');
+      $source['urls'] = $file->getFileUri();
+      $migration->set('source', $source);
+      $migration->save();
+    }
+
+    return $this;
+  }
+
+  /**
+   * Set the user id to be passed to all migrations.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The user id to pass to the migration configuration when processing.
+   *
+   * @return $this
+   */
+  public function setUser(AccountInterface $user) {
+    $this->sourceOverrides['source']['constants']['user_id'] = $user->id();
+
+    return $this;
+  }
+
+  /**
+   * Change the MigrateMessage class if need be.
+   *
+   * @param \Drupal\migrate\MigrateMessageInterface $messenger
+   *   The new migrate message object.
+   *
+   * @return $this
+   */
+  public function setMessenger(MigrateMessageInterface $messenger) {
+    $this->migrateMessage = $messenger;
+
+    return $this;
+  }
+
+  /**
+   * Fetches an array of migrations to run to import the Annual Report XML.
+   *
+   * @return string[]
+   *   List of migrations.
+   */
+  public function getMigrationsList() {
+    $migrations_list = [
+      'component',
+      'component_ix_personnel',
+      'component_iv_statutes',
+      'component_va_requests',
+      'component_vb1_requests',
+      'component_vb2_requests',
+      'component_vb3_requests',
+      'component_via_disposition',
+      'component_vib_disposition',
+      'component_vic1_applied_exemptions',
+      'component_vic2_nonexemption_denial',
+      'component_vic3_other_denial',
+      'component_vic4_response_time',
+      'component_vic5_oldest_pending',
+      'component_viia_processed_requests',
+      'component_viib_processed_requests',
+      'component_viic1_simple_response',
+      'component_viic2_complex_response',
+      'component_viic3_expedited_response',
+      'component_viid_pending_requests',
+      'component_viie_oldest_pending',
+      'component_viiia_expedited_processing',
+      'component_viiib_fee_waiver',
+      'component_xia_subsection_c',
+      'component_xib_subsection_a2',
+      'component_xiia',
+      'component_xiib',
+      'component_xiic',
+      'component_xiid1',
+      'component_xiid2',
+      'component_xiie1',
+      'component_xiie2',
+      'component_x_fees',
+      'foia_vb2_other',
+      'foia_vic3_other',
+      'foia_iv_details',
+      'foia_iv_statute',
+      'foia_va_requests',
+      'foia_vb1_requests',
+      'foia_vb2',
+      'foia_vb3_requests',
+      'foia_via_disposition',
+      'foia_vib_disposition',
+      'foia_vic1_applied_exemptions',
+      'foia_vic2_nonexemption_denial',
+      'foia_vic3',
+      'foia_vic4_response_time',
+      'foia_vic5_oldest_pending',
+      'foia_viia_processed_requests',
+      'foia_viib_processed_requests',
+      'foia_viic1_simple_response',
+      'foia_viic2_complex_response',
+      'foia_viic3_expedited_response',
+      'foia_viid_pending_requests',
+      'foia_viie_oldest_pending',
+      'foia_viiia_expedited_processing',
+      'foia_viiib_fee_waiver',
+      'foia_ix_personnel',
+      'foia_x_fees',
+      'foia_xia_subsection_c',
+      'foia_xib_subsection_a2',
+      'foia_xiia',
+      'foia_xiib',
+      'foia_xiic',
+      'foia_xiid1',
+      'foia_xiid2',
+      'foia_xiie1',
+      'foia_xiie2',
+      'foia_agency_report',
+    ];
+
+    return $migrations_list;
+  }
+
+}

--- a/docroot/modules/custom/foia_upload_xml/src/FoiaUploadXmlMigrationsProcessor.php
+++ b/docroot/modules/custom/foia_upload_xml/src/FoiaUploadXmlMigrationsProcessor.php
@@ -103,7 +103,7 @@ class FoiaUploadXmlMigrationsProcessor {
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function setSourceFile(FileInterface $file) {
-    $this->sourceOverrides['source']['urls'] = [$file->getFileUri()];
+    $this->sourceOverrides['source']['urls'] = $file->getFileUri();
 
     return $this;
   }

--- a/docroot/modules/custom/foia_upload_xml/src/FoiaUploadXmlReportParser.php
+++ b/docroot/modules/custom/foia_upload_xml/src/FoiaUploadXmlReportParser.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Drupal\foia_upload_xml;
+
+use Drupal\file\FileInterface;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\migrate_plus\DataParserPluginManager;
+
+/**
+ * Default configuration to parse and retrieve key fields from upload files.
+ *
+ * @package Drupal\foia_upload_xml
+ */
+class FoiaUploadXmlReportParser {
+
+  /**
+   * The data parser plugin manager.
+   *
+   * @var \Drupal\migrate_plus\DataParserPluginManager
+   */
+  protected $dataParserPluginManager;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * SimpleXml data parser configuration for fetching report data.
+   *
+   * @var array
+   */
+  protected $simpleXmlParserConfig = [
+    'data_fetcher_plugin' => 'file',
+    'namespaces' => [
+      'iepd' => 'http://leisp.usdoj.gov/niem/FoiaAnnualReport/exchange/1.03',
+      'foia' => 'http://leisp.usdoj.gov/niem/FoiaAnnualReport/extension/1.03',
+      'nc' => 'http://niem.gov/niem/niem-core/2.0',
+    ],
+    'item_selector' => '/iepd:FoiaAnnualReport/foia:DocumentFiscalYearDate|/iepd:FoiaAnnualReport/nc:Organization/nc:OrganizationAbbreviationText',
+    'fields' => [
+      [
+        'name' => 'report_year',
+        'selector' => '/iepd:FoiaAnnualReport/foia:DocumentFiscalYearDate',
+      ],
+      [
+        'name' => 'agency',
+        'selector' => '/iepd:FoiaAnnualReport/nc:Organization/nc:OrganizationAbbreviationText',
+      ],
+    ],
+    'ids' => [
+      "report_year" => ['type' => 'integer'],
+      "agency" => ['type' => 'string'],
+    ],
+  ];
+
+  /**
+   * FoiaUploadXmlReportParser constructor.
+   *
+   * @param \Drupal\migrate_plus\DataParserPluginManager $dataParserPluginManager
+   *   The data parser plugin manager service.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(DataParserPluginManager $dataParserPluginManager, EntityTypeManager $entityTypeManager) {
+    $this->dataParserPluginManager = $dataParserPluginManager;
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * Get xml data from an uploaded annual report xml file.
+   *
+   * @param \Drupal\file\FileInterface $file
+   *   The report file to parse.
+   *
+   * @return mixed
+   *   An array of data from the xml file given.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   */
+  public function parse(FileInterface $file) {
+    $this->simpleXmlParserConfig['urls'] = [$file->getFileUri()];
+    $simple_xml_parser = $this->dataParserPluginManager->createInstance('simple_xml', $this->simpleXmlParserConfig);
+
+    $simple_xml_parser->rewind();
+    $data = $simple_xml_parser->current();
+    unset($simple_xml_parser);
+
+    $data['agency_tid'] = $this->getAgencyFromAbbreviation($data['agency'] ?? FALSE);
+
+    return $data;
+  }
+
+  /**
+   * Lookup an agency taxonomy term id from the agency's abbreviated name.
+   *
+   * @param string $agency_abbreviation
+   *   An agency's abbreviated name.
+   *
+   * @return bool|mixed
+   *   The agency's taxonomy term id or FALSE if not found.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function getAgencyFromAbbreviation($agency_abbreviation) {
+    if (!$agency_abbreviation) {
+      return FALSE;
+    }
+
+    $term_query = $this->entityTypeManager->getStorage('taxonomy_term')
+      ->getQuery()
+      ->condition('vid', 'agency')
+      ->condition('field_agency_abbreviation', $agency_abbreviation);
+
+    $tids = $term_query->execute();
+
+    return !empty($tids) ? reset($tids) : FALSE;
+  }
+
+}

--- a/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
@@ -159,7 +159,7 @@ class AgencyXmlUploadForm extends FormBase {
     $queue = \Drupal::service('queue')->get('foia_xml_report_import_worker');
     $queue->createItem($item);
 
-    \Drupal::messenger()->addStatus($this->t('Your report has been added to the queue.  Please check back in 15 minutes.'));
+    \Drupal::messenger()->addStatus($this->t('Your report has been queued. It will appear in your home page once it has successfully uploaded. You may navigate away from this page and check back shortly.'));
     $form_state->setRedirect('user.page');
   }
 

--- a/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
@@ -210,11 +210,10 @@ class AgencyXmlUploadForm extends FormBase {
   protected function getBatchOperations(FileInterface $sourceFile) {
     /** @var \Drupal\foia_upload_xml\FoiaUploadXmlMigrationsProcessor */
     $processor = \Drupal::service('foia_upload_xml.migrations_processor');
-    $processor = $processor->setSourceFile($sourceFile);
     $operations = [];
     foreach ($processor->getMigrationsList() as $migration_list_item) {
       $operations[] = ['foia_upload_xml_execute_migration',
-        [$migration_list_item],
+        [$migration_list_item, $sourceFile],
       ];
     }
 

--- a/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
@@ -160,6 +160,7 @@ class AgencyXmlUploadForm extends FormBase {
     $queue->createItem($item);
 
     \Drupal::messenger()->addStatus($this->t('Your report has been added to the queue.  Please check back in 15 minutes.'));
+    $form_state->setRedirect('user.page');
   }
 
   /**

--- a/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
@@ -2,13 +2,15 @@
 
 namespace Drupal\foia_upload_xml\Form;
 
+use Drupal\file\FileInterface;
+use Drupal\user\UserInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\foia_upload_xml\ReportUploadValidator;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\user\Entity\User;
-use Drupal\migrate_plus\Entity\Migration;
 
 /**
  * Class AgencyXmlUploadForm.
@@ -98,14 +100,6 @@ class AgencyXmlUploadForm extends FormBase {
     // form is actually being submitted.
     $element = $form_state->getTriggeringElement();
     if ($element['#id'] == 'edit-submit') {
-      // Attempt to get a lock, tell them to try again if we can't.
-      $lock = \Drupal::service('lock.persistent');
-      // This is released in foia_upload_xml_execute_migration_finished().
-      if (!$lock->acquire('foia_upload_xml', 3600)) {
-        $form_state->setErrorByName('submit',
-          $this->t("Another Agency's import is running; please re-submit in a few minutes."));
-      }
-
       // Don't allow processing a report upload if the reporting agency has
       // an existing report in the current calendar year whose workflow
       // state indicates that it has been submitted or cleared.
@@ -114,49 +108,61 @@ class AgencyXmlUploadForm extends FormBase {
         $this->reportValidator->validate($file, $form_state);
       }
     }
-
-    if (!empty($form_state->getErrors())) {
-      \Drupal::service('lock.persistent')->release('foia_upload_xml');
-    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $fid = $form_state->getValue(['agency_report_xml', 0]);
-    if (empty($fid)) {
-      return;
+    // Attempt to get a lock, tell them to try again if we can't.
+    $lock = \Drupal::service('lock.persistent');
+
+    // This is released in foia_upload_xml_execute_migration_finished().
+    if ($lock->acquire('foia_upload_xml', 3600)) {
+      $this->process($form_state);
     }
+    else {
+      $this->queue($form_state);
+    }
+  }
 
-    $file_storage = $this->entityTypeManager->getStorage('file');
-    $file = $file_storage->load($fid);
-    // If we do not use temporary, then we should add $file->setPermanent().
-    $file->save();
-    $directory = 'temporary://foia-xml';
-    \Drupal::service('file_system')->prepareDirectory($directory, FILE_CREATE_DIRECTORY);
-
-    // Get the user's agency abbreviation to put in the file name, so that
-    // simulataneous uploads don't wipe out each other's files.
+  /**
+   * Add a report upload file to be processed by the queue.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current form state.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function queue(FormStateInterface $form_state) {
     $user = User::load(\Drupal::currentUser()->id());
-    $user_agency_nid = $user->get('field_agency')->target_id;
-    $xml_upload_filename =
-      "$directory/report_" . date('Y') . "_" . $user_agency_nid . ".xml";
-    file_move($file, $xml_upload_filename, FILE_EXISTS_REPLACE);
+    $file = $this->getUploadedFile($form_state);
+    $file = $this->prepareFile($file, $user, 'public');
 
-    // Load the migrations, set them to use this new filename, and save them.
-    $migrations_list = $this->getMigrationsList();
-    foreach ($migrations_list as $migration_list_item) {
-      $migration = Migration::load($migration_list_item);
-      $source = $migration->get('source');
-      $source['urls'] = $xml_upload_filename;
-      $migration->set('source', $source);
-      $migration->save();
-    }
+    $this->addToQueue($file, $user);
+    \Drupal::messenger()->addStatus($this->t('Your report has been added to the queue.  Please check back in 15 minutes.'));
+  }
+
+  /**
+   * Process an uploaded report file immediately via the batch api.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current form state.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function process(FormStateInterface $form_state) {
+    $user = User::load(\Drupal::currentUser()->id());
+    $file = $this->getUploadedFile($form_state);
+    $file = $this->prepareFile($file, $user, 'temporary');
 
     $batch = [
       'title' => $this->t('Importing Annual Report XML Data...'),
-      'operations' => $this->getBatchOperations(),
+      'operations' => $this->getBatchOperations($file),
       'init_message' => $this->t('Commencing import'),
       'progress_message' => $this->t('Imported @current out of @total'),
       'error_message' => $this->t('An error occurred during import'),
@@ -168,97 +174,20 @@ class AgencyXmlUploadForm extends FormBase {
   }
 
   /**
-   * Fetches an array of migrations to run to import the Annual Report XML.
-   *
-   * @return string[]
-   *   List of migrations.
-   */
-  protected function getMigrationsList() {
-    $migrations_list = [
-      'component',
-      'component_ix_personnel',
-      'component_iv_statutes',
-      'component_va_requests',
-      'component_vb1_requests',
-      'component_vb2_requests',
-      'component_vb3_requests',
-      'component_via_disposition',
-      'component_vib_disposition',
-      'component_vic1_applied_exemptions',
-      'component_vic2_nonexemption_denial',
-      'component_vic3_other_denial',
-      'component_vic4_response_time',
-      'component_vic5_oldest_pending',
-      'component_viia_processed_requests',
-      'component_viib_processed_requests',
-      'component_viic1_simple_response',
-      'component_viic2_complex_response',
-      'component_viic3_expedited_response',
-      'component_viid_pending_requests',
-      'component_viie_oldest_pending',
-      'component_viiia_expedited_processing',
-      'component_viiib_fee_waiver',
-      'component_xia_subsection_c',
-      'component_xib_subsection_a2',
-      'component_xiia',
-      'component_xiib',
-      'component_xiic',
-      'component_xiid1',
-      'component_xiid2',
-      'component_xiie1',
-      'component_xiie2',
-      'component_x_fees',
-      'foia_vb2_other',
-      'foia_vic3_other',
-      'foia_iv_details',
-      'foia_iv_statute',
-      'foia_va_requests',
-      'foia_vb1_requests',
-      'foia_vb2',
-      'foia_vb3_requests',
-      'foia_via_disposition',
-      'foia_vib_disposition',
-      'foia_vic1_applied_exemptions',
-      'foia_vic2_nonexemption_denial',
-      'foia_vic3',
-      'foia_vic4_response_time',
-      'foia_vic5_oldest_pending',
-      'foia_viia_processed_requests',
-      'foia_viib_processed_requests',
-      'foia_viic1_simple_response',
-      'foia_viic2_complex_response',
-      'foia_viic3_expedited_response',
-      'foia_viid_pending_requests',
-      'foia_viie_oldest_pending',
-      'foia_viiia_expedited_processing',
-      'foia_viiib_fee_waiver',
-      'foia_ix_personnel',
-      'foia_x_fees',
-      'foia_xia_subsection_c',
-      'foia_xib_subsection_a2',
-      'foia_xiia',
-      'foia_xiib',
-      'foia_xiic',
-      'foia_xiid1',
-      'foia_xiid2',
-      'foia_xiie1',
-      'foia_xiie2',
-      'foia_agency_report',
-    ];
-
-    return $migrations_list;
-  }
-
-  /**
    * Operations for batch process.
+   *
+   * @param \Drupal\file\FileInterface $sourceFile
+   *   The data source to be processed.
    *
    * @return array
    *   Array of operations to execute via batch.
    */
-  protected function getBatchOperations() {
-    $migrations_list = $this->getMigrationsList();
+  protected function getBatchOperations(FileInterface $sourceFile) {
+    /** @var \Drupal\foia_upload_xml\FoiaUploadXmlMigrationsProcessor */
+    $processor = \Drupal::service('foia_upload_xml.migrations_processor');
+    $processor = $processor->setSourceFile($sourceFile);
     $operations = [];
-    foreach ($migrations_list as $migration_list_item) {
+    foreach ($processor->getMigrationsList() as $migration_list_item) {
       $operations[] = ['foia_upload_xml_execute_migration',
         [$migration_list_item],
       ];
@@ -268,13 +197,33 @@ class AgencyXmlUploadForm extends FormBase {
   }
 
   /**
+   * Create a queue item and add it to the foia_xml_report_import_worker queue.
+   *
+   * @param \Drupal\file\FileInterface $file
+   *   The data source file to be processed later.
+   * @param \Drupal\Core\Entity\EntityInterface|null $user
+   *   The user uploading the source file.
+   */
+  protected function addToQueue(FileInterface $file, EntityInterface $user) {
+    $item = new \stdClass();
+    $item->fid = $file->id();
+    $item->uid = $user->id();
+    $item->agency = $user->get('field_agency')->target_id;
+    $item->report_year = date('Y');
+
+    /** @var \Drupal\Core\Queue\QueueInterface $queue */
+    $queue = \Drupal::service('queue')->get('foia_xml_report_import_worker');
+    $queue->createItem($item);
+  }
+
+  /**
    * Load the file uploaded in the agency_report_xml field.
    *
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The current form state.
    *
-   * @return bool|\Drupal\Core\Entity\EntityInterface|null
-   *   The uploaded file object or FALSE if one does not exist.
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   The uploaded file object or NULL if one does not exist.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
@@ -282,11 +231,48 @@ class AgencyXmlUploadForm extends FormBase {
   protected function getUploadedFile(FormStateInterface $form_state) {
     $fid = $form_state->getValue(['agency_report_xml', 0]);
     if (empty($fid)) {
-      return FALSE;
+      return NULL;
     }
 
     $file_storage = $this->entityTypeManager->getStorage('file');
     return $file_storage->load($fid);
+  }
+
+  /**
+   * Save and rename the uploaded file.
+   *
+   * @param \Drupal\file\FileInterface $file
+   *   The uploaded file.
+   * @param \Drupal\user\UserInterface $user
+   *   The user that uploaded the file.
+   * @param string $file_scheme
+   *   The file scheme to use when moving the file.  Either temporary,
+   *   public, or private.
+   *
+   * @return \Drupal\file\FileInterface
+   *   The uploaded file after it has been moved.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function prepareFile(FileInterface $file, UserInterface $user, string $file_scheme = 'temporary') {
+    if (!$file_scheme == 'temporary') {
+      // Store the file permanently so that it still exists when the queue goes
+      // to process it.
+      $file->setPermanent();
+    }
+
+    $file->save();
+    $directory = $file_scheme . '://foia-xml';
+    \Drupal::service('file_system')
+      ->prepareDirectory($directory, FILE_CREATE_DIRECTORY);
+
+    // Get the user's agency abbreviation to put in the file name, so that
+    // simultaneous uploads don't wipe out each other's files.
+    $user_agency_nid = $user->get('field_agency')->target_id;
+    $xml_upload_filename = "$directory/report_" . date('Y') . "_" . $user_agency_nid . ".xml";
+    $file = file_move($file, $xml_upload_filename, FILE_EXISTS_REPLACE);
+
+    return $file;
   }
 
 }

--- a/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Form/AgencyXmlUploadForm.php
@@ -152,8 +152,8 @@ class AgencyXmlUploadForm extends FormBase {
     $item = new \stdClass();
     $item->fid = $file->id();
     $item->uid = $user->id();
-    $item->agency = $report_data['agency_tid'] ?? FALSE;
-    $item->report_year = $report_data['report_year'] ?? FALSE;
+    $item->agency = $report_data['agency_tid'] ?? $user->get('field_agency')->target_id;
+    $item->report_year = $report_data['report_year'] ?? date('Y');
 
     /** @var \Drupal\Core\Queue\QueueInterface $queue */
     $queue = \Drupal::service('queue')->get('foia_xml_report_import_worker');

--- a/docroot/modules/custom/foia_upload_xml/src/Plugin/QueueWorker/FoiaXmlReportImportWorker.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Plugin/QueueWorker/FoiaXmlReportImportWorker.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\foia_upload_xml\Plugin\QueueWorker;
+
+use Drupal\file\Entity\File;
+use Drupal\user\Entity\User;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\Core\Queue\RequeueException;
+use Drupal\Core\File\Exception\FileNotExistsException;
+
+/**
+ * Import uploaded report xml files on cron.
+ *
+ * @QueueWorker(
+ *   id = "foia_xml_report_import_worker",
+ *   title = @Translation("FOIA Xml Report Importer"),
+ *   cron = {"time" = 600}
+ * )
+ */
+class FoiaXmlReportImportWorker extends QueueWorkerBase {
+
+  /**
+   * The list of migrations to run.
+   *
+   * @var \Drupal\foia_upload_xml\FoiaUploadXmlMigrationsProcessor
+   */
+  protected $migrationsProcessor;
+
+  /**
+   * Process a foia_xml_report_import_worker queue item.
+   *
+   * @param mixed $data
+   *   The queue item to process.
+   *
+   * @throws \Exception
+   */
+  public function processItem($data) {
+    $lock = \Drupal::service('lock.persistent');
+    if (!$lock->acquire('foia_upload_xml', 3600)) {
+      throw new RequeueException('The foia_upload_xml lock could not be acquired.');
+    }
+
+    $this->migrationsProcessor = \Drupal::service('foia_upload_xml.migrations_processor');
+
+    try {
+      $source = File::load($data->fid);
+      if (!$source) {
+        throw new FileNotExistsException();
+      }
+
+      $user = User::load($data->uid);
+      $this->migrationsProcessor
+        ->setSourceFile($source)
+        ->setUser($user)
+        ->processAll();
+
+      $source->delete();
+    }
+    catch (FileNotExistsException $e) {
+      throw new \Exception(t('Could not load file @fid when attempting to process the annual report queue.  Agency: @agency Year: @year', [
+        '@fid' => $data->fid,
+        '@agency' => $data->agency,
+        '@year' => $data->report_year,
+      ]));
+    }
+    catch (\Exception $e) {
+      throw new \Exception(t('Attempt to process file @fid in the annual report queue failed.  Agency: @agency Year: @year', [
+        '@fid' => $data->fid,
+        '@agency' => $data->agency,
+        '@year' => $data->report_year,
+      ]));
+    }
+    finally {
+      \Drupal::service('lock.persistent')->release('foia_upload_xml');
+    }
+  }
+
+}

--- a/docroot/modules/custom/foia_upload_xml/src/Plugin/migrate/FoiaUploadXmlMigration.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Plugin/migrate/FoiaUploadXmlMigration.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\foia_upload_xml\Plugin\migrate;
+
+use Drupal\migrate\Plugin\Migration;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Plugin\RequirementsInterface;
+use Drupal\migrate\Exception\RequirementsException;
+
+/**
+ * Custom migration plugin for report xml upload processing.
+ *
+ * @package Drupal\foia_upload_xml\Plugin\migrate
+ */
+class FoiaUploadXmlMigration extends Migration {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function checkRequirements() {
+    // Check whether the current migration source and destination plugin
+    // requirements are met or not.
+    if ($this->getSourcePlugin() instanceof RequirementsInterface) {
+      $this->getSourcePlugin()->checkRequirements();
+    }
+    if ($this->getDestinationPlugin() instanceof RequirementsInterface) {
+      $this->getDestinationPlugin()->checkRequirements();
+    }
+
+    if (empty($this->requirements)) {
+      // There are no requirements to check.
+      return;
+    }
+    /** @var \Drupal\migrate\Plugin\MigrationInterface[] $required_migrations */
+    $required_migrations = $this->getMigrationPluginManager()->createInstances($this->requirements);
+
+    $missing_migrations = array_diff($this->requirements, array_keys($required_migrations));
+    // Check if the dependencies are in good shape.
+    foreach ($required_migrations as $migration_id => $required_migration) {
+      // Configures the source url of dependent migrations to use the same
+      // source url as the current migration.  This ensures that when checking
+      // that dependencies have run, the dependencies attempt to access data
+      // in the correct, and existing, source file.
+      $required_migration = $this->setMigrationSourceUrls($required_migration);
+      if (!$required_migration->allRowsProcessed()) {
+        $missing_migrations[] = $migration_id;
+      }
+    }
+    if ($missing_migrations) {
+      throw new RequirementsException('Missing migrations ' . implode(', ', $missing_migrations) . '.', ['requirements' => $missing_migrations]);
+    }
+  }
+
+  /**
+   * Set source urls of a migration to match the current migration's source url.
+   *
+   * @param \Drupal\migrate\Plugin\MigrationInterface $migration
+   *   The migration to set the source urls of.
+   *
+   * @return \Drupal\migrate\Plugin\MigrationInterface
+   *   The migration with updated source urls.
+   */
+  public function setMigrationSourceUrls(MigrationInterface $migration) {
+    $source = $migration->getSourceConfiguration();
+    $source['urls'] = $this->configuration['source']['urls'] ?? $source['urls'];
+    $migration->set('source', $source);
+
+    return $migration;
+  }
+
+}

--- a/docroot/modules/custom/foia_upload_xml/src/ReportUploadValidator.php
+++ b/docroot/modules/custom/foia_upload_xml/src/ReportUploadValidator.php
@@ -19,13 +19,6 @@ class ReportUploadValidator {
   use DependencySerializationTrait;
 
   /**
-   * An array of report data parsed from the xml file.
-   *
-   * @var array
-   */
-  private $data;
-
-  /**
    * The entity type manager.
    *
    * @var \Drupal\Core\Entity\EntityTypeManager

--- a/docroot/modules/custom/foia_upload_xml/src/ReportUploadValidator.php
+++ b/docroot/modules/custom/foia_upload_xml/src/ReportUploadValidator.php
@@ -6,8 +6,8 @@ use Drupal\node\Entity\Node;
 use Drupal\file\FileInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityTypeManager;
-use Drupal\migrate_plus\DataParserPluginManager;
 use Drupal\Core\TypedData\Exception\MissingDataException;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 
 /**
  * Validates that an uploaded report can overwrite existing report data.
@@ -16,12 +16,14 @@ use Drupal\Core\TypedData\Exception\MissingDataException;
  */
 class ReportUploadValidator {
 
+  use DependencySerializationTrait;
+
   /**
-   * The data parser plugin manager.
+   * An array of report data parsed from the xml file.
    *
-   * @var \Drupal\migrate_plus\DataParserPluginManager
+   * @var array
    */
-  protected $dataParserPluginManager;
+  private $data;
 
   /**
    * The entity type manager.
@@ -31,51 +33,23 @@ class ReportUploadValidator {
   protected $entityTypeManager;
 
   /**
-   * The uploaded file.
+   * The report xml parser.
    *
-   * @var \Drupal\file\FileInterface
+   * @var \Drupal\foia_upload_xml\FoiaUploadXmlReportParser
    */
-  protected $file;
-
-  /**
-   * SimpleXml data parser configuration for fetching report data.
-   *
-   * @var array
-   */
-  protected $simpleXmlParserConfig = [
-    'data_fetcher_plugin' => 'file',
-    'namespaces' => [
-      'iepd' => 'http://leisp.usdoj.gov/niem/FoiaAnnualReport/exchange/1.03',
-      'foia' => 'http://leisp.usdoj.gov/niem/FoiaAnnualReport/extension/1.03',
-      'nc' => 'http://niem.gov/niem/niem-core/2.0',
-    ],
-    'item_selector' => '/iepd:FoiaAnnualReport/foia:DocumentFiscalYearDate|/iepd:FoiaAnnualReport/nc:Organization/nc:OrganizationAbbreviationText',
-    'fields' => [
-      [
-        'name' => 'report_year',
-        'selector' => '/iepd:FoiaAnnualReport/foia:DocumentFiscalYearDate',
-      ],
-      [
-        'name' => 'agency',
-        'selector' => '/iepd:FoiaAnnualReport/nc:Organization/nc:OrganizationAbbreviationText',
-      ],
-    ],
-    'ids' => [
-      "report_year" => ['type' => 'integer'],
-      "agency" => ['type' => 'string'],
-    ],
-  ];
+  protected $foiaUploadXmlReportParser;
 
   /**
    * ReportUploadValidator constructor.
    *
-   * @param \Drupal\migrate_plus\DataParserPluginManager $dataParserPluginManager
-   *   The data parser plugin manager service.
+   * @param \Drupal\foia_upload_xml\FoiaUploadXmlReportParser $foiaUploadXmlReportParser
+   *   The custom parser that gets the report year and agency abbreviation by
+   *   default.
    * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
    *   The entity type manager service.
    */
-  public function __construct(DataParserPluginManager $dataParserPluginManager, EntityTypeManager $entityTypeManager) {
-    $this->dataParserPluginManager = $dataParserPluginManager;
+  public function __construct(FoiaUploadXmlReportParser $foiaUploadXmlReportParser, EntityTypeManager $entityTypeManager) {
+    $this->foiaUploadXmlReportParser = $foiaUploadXmlReportParser;
     $this->entityTypeManager = $entityTypeManager;
   }
 
@@ -88,20 +62,22 @@ class ReportUploadValidator {
    *   The form state object on which to set errors.
    */
   public function validate(FileInterface $file, FormStateInterface $form_state) {
-    $this->file = $file;
-
-    $file_data = $this->getFileData();
-    $agency_tid = $this->getAgencyFromAbbreviation($file_data['agency'] ?? FALSE);
+    $file_data = $this->foiaUploadXmlReportParser->parse($file);
     $report_year = isset($file_data['report_year']) && !empty($file_data['report_year']) ? (int) $file_data['report_year'] : (int) date('Y');
 
     // If an agency can't be found, allow the upload to continue.
-    if (!$agency_tid) {
+    if (!$file_data['agency_tid']) {
       return;
     }
 
-    if ($this->agencyReportYearIsLocked($agency_tid, $report_year)) {
+    if ($this->agencyReportYearIsLocked($file_data['agency_tid'], $report_year)) {
       $form_state->setErrorByName('submit', \Drupal::translation()
         ->translate("Your agency’s report has already been submitted. If you need to make changes to your agency’s report, please contact OIP."));
+    }
+
+    if ($this->agencyReportYearIsQueued($file_data['agency_tid'], $report_year)) {
+      $form_state->setErrorByName('submit', \Drupal::translation()
+        ->translate("Your agency's report has already been queued for processing.  It cannot be uploaded again until the previous upload has been processed, which takes place every 15 minutes."));
     }
   }
 
@@ -140,6 +116,40 @@ class ReportUploadValidator {
   }
 
   /**
+   * Check if the given agency and year already has an xml file in the queue.
+   *
+   * @param string $agency_tid
+   *   The agency taxonomy term id to validate against.
+   * @param int $year
+   *   The annual report year to validate against.
+   *
+   * @return bool
+   *   TRUE if a report is queued and this file should not be uploaded, FALSE
+   *   if there is no report in the queue and this validation passes.
+   */
+  public function agencyReportYearIsQueued($agency_tid = NULL, $year = NULL) {
+    if (!$agency_tid) {
+      return FALSE;
+    }
+
+    $year = $year ? (int) $year : (int) date('Y');
+    $queue_items = \Drupal::database()
+      ->select('queue', 'q')
+      ->fields('q')
+      ->condition('name', 'foia_xml_report_import_worker', '=')
+      ->execute();
+
+    foreach ($queue_items as $queue_item) {
+      $data = unserialize($queue_item->data);
+      if ($data->agency == $agency_tid && $data->report_year == $year) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
    * Check if a report is in a workflow state in which it should not be updated.
    *
    * @param \Drupal\node\Entity\Node $node
@@ -157,52 +167,6 @@ class ReportUploadValidator {
       'cleared',
       'published',
     ]);
-  }
-
-  /**
-   * Get data from the uploaded file using the SimpleXml parser.
-   *
-   * @return array
-   *   Report data retrieved from the xpath configuration.
-   *
-   * @throws \Drupal\Component\Plugin\Exception\PluginException
-   */
-  protected function getFileData() {
-    $this->simpleXmlParserConfig['urls'] = [$this->file->getFileUri()];
-    $simple_xml_parser = $this->dataParserPluginManager->createInstance('simple_xml', $this->simpleXmlParserConfig);
-
-    $simple_xml_parser->rewind();
-    $data = $simple_xml_parser->current();
-    unset($simple_xml_parser);
-
-    return $data;
-  }
-
-  /**
-   * Lookup an agency taxonomy term id from the agency's abbreviated name.
-   *
-   * @param string $agency_abbreviation
-   *   An agency's abbreviated name.
-   *
-   * @return bool|mixed
-   *   The agency's taxonomy term id or FALSE if not found.
-   *
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   */
-  protected function getAgencyFromAbbreviation($agency_abbreviation) {
-    if (!$agency_abbreviation) {
-      return FALSE;
-    }
-
-    $term_query = $this->entityTypeManager->getStorage('taxonomy_term')
-      ->getQuery()
-      ->condition('vid', 'agency')
-      ->condition('field_agency_abbreviation', $agency_abbreviation);
-
-    $tids = $term_query->execute();
-
-    return !empty($tids) ? reset($tids) : FALSE;
   }
 
   /**

--- a/docroot/modules/custom/foia_upload_xml/src/ReportUploadValidator.php
+++ b/docroot/modules/custom/foia_upload_xml/src/ReportUploadValidator.php
@@ -70,7 +70,7 @@ class ReportUploadValidator {
 
     if ($this->agencyReportYearIsQueued($file_data['agency_tid'], $report_year)) {
       $form_state->setErrorByName('submit', \Drupal::translation()
-        ->translate("Your agency's report has already been queued for processing.  It cannot be uploaded again until the previous upload has been processed, which takes place every 15 minutes."));
+        ->translate("Your agency already uploaded a report for the fiscal year. You may continue working on the existing report. Or you may start over by deleting the existing report before uploading a new XML"));
     }
   }
 


### PR DESCRIPTION
* Adds a queue worker to process uploads on cron
* Adds a migration processor to centralize how report import migrations are processed and uses that in the batch importer and the queue worker
* Puts uploads in a queue to be processed later if there is already an upload that is being processed at that moment.
* Adds and enables the queue_ui module
* Adds validation to the AgencyXmlUploadForm that checks if the agency and report year of the file being uploaded are in the queue or not. If yes, validation fails and the report cannot be uploaded until that queue item has been processed.
* Adds a custom migration class to the `foia_upload_xml` module that passes source url configuration down to required migrations when checking that dependencies have been run.