### PR TITLE
FOIA-189: Add page breaks to Word docx files

### DIFF
--- a/docroot/modules/custom/node_to_docx/src/NodeToDocxHandler.php
+++ b/docroot/modules/custom/node_to_docx/src/NodeToDocxHandler.php
@@ -69,7 +69,7 @@ class NodeToDocxHandler implements ContainerAwareInterface {
    */
   private function generateDocxFromHtml($html, $file_name_output) {
     $docx = new CreateDocx();
-    $docx->embedHTML($html);
+    $docx->embedHTML($html, ['useHTMLExtended' => TRUE]);
 
     $file_path = drupal_realpath(file_default_scheme() . '://');
     $docx->modifyPageLayout('letter-landscape');

--- a/docroot/modules/custom/node_to_docx/templates/docx-agency-component-abbrev.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-agency-component-abbrev.html.twig
@@ -38,3 +38,4 @@
 
 <br clear=all >
 
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-iv-exemption-3-statutes.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-iv-exemption-3-statutes.html.twig
@@ -99,5 +99,4 @@
 
 </div>
 
-<i ><br clear=all >
-</i>
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-ix-foia-personnel-costs.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-ix-foia-personnel-costs.html.twig
@@ -131,6 +131,4 @@
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-va-foia-requests.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-va-foia-requests.html.twig
@@ -109,3 +109,5 @@ AND PENDING FOIA REQUESTS<o:p></o:p></b></p>
 </table>
 
 </div>
+
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vb-disposition-foia-requests.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vb-disposition-foia-requests.html.twig
@@ -234,5 +234,4 @@ DISPOSITION OF FOIA REQUESTS -- ALL PROCESSED REQUESTS<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vb2-disposition-foia-requests-other.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vb2-disposition-foia-requests-other.html.twig
@@ -95,5 +95,4 @@ DENIALS BASED ON REASONS OTHER THAN EXEMPTIONS&quot;<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vb3-disposition-number-of-times.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vb3-disposition-number-of-times.html.twig
@@ -204,5 +204,4 @@ DISPOSITION OF FOIA REQUESTS -- NUMBER OF TIMES EXEMPTIONS APPLIED<o:p></o:p></b
 
 </div>
 
-<i ><br clear=all >
-</i>
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-via-administrative-appeals.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-via-administrative-appeals.html.twig
@@ -105,6 +105,4 @@ ADMINISTRATIVE APPEALS<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vib-administrative-appeals.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vib-administrative-appeals.html.twig
@@ -108,6 +108,4 @@
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vic-reasons-denial.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vic-reasons-denial.html.twig
@@ -206,5 +206,4 @@ EXEMPTIONS APPLIED<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vic2-reasons-other.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vic2-reasons-other.html.twig
@@ -173,5 +173,4 @@ REASONS FOR DENIAL ON APPEAL -- REASONS OTHER THAN EXEMPTIONS<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vic3-reasons-other.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vic3-reasons-other.html.twig
@@ -91,6 +91,4 @@ REASONS FOR DENIAL ON APPEAL -- &quot;OTHER&quot; REASONS<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vic4-response-time.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vic4-response-time.html.twig
@@ -94,5 +94,4 @@ RESPONSE TIME FOR ADMINISTRATIVE APPEALS<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vic5-ten-oldest-pending.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vic5-ten-oldest-pending.html.twig
@@ -259,6 +259,4 @@ OLDEST PENDING ADMINISTRATIVE APPEALS<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viia-response-time.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viia-response-time.html.twig
@@ -193,6 +193,4 @@ ALL PROCESSED PERFECTED REQUESTS<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viib-processed-requests-response-time.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viib-processed-requests-response-time.html.twig
@@ -193,6 +193,4 @@ TIME FOR PERFECTED REQUESTS IN WHICH INFORMATION WAS GRANTED<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viic-processed-complex-ten-day.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viic-processed-complex-ten-day.html.twig
@@ -209,6 +209,4 @@ RESPONSE TIME IN DAY INCREMENTS<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viic-processed-expedited-ten-day.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viic-processed-expedited-ten-day.html.twig
@@ -206,6 +206,4 @@ EXPEDITED PROCESSING -- RESPONSE TIME IN DAY INCREMENTS<o:p></o:p></b></p>
 </table>
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viic-processed-simple-ten-day.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viic-processed-simple-ten-day.html.twig
@@ -209,6 +209,4 @@ RESPONSE TIME IN DAY INCREMENTS<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viid-pending-requests.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viid-pending-requests.html.twig
@@ -159,6 +159,4 @@ PERFECTED REQUESTS<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viie-pending-requests-ten-oldest.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viie-pending-requests-ten-oldest.html.twig
@@ -258,6 +258,4 @@ PENDING PERFECTED REQUESTS<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viiia-requests-expedited.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viiia-requests-expedited.html.twig
@@ -104,6 +104,4 @@
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viiib-requests-fee-waiver.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viiib-requests-fee-waiver.html.twig
@@ -84,5 +84,4 @@
 
 </div>
 
-<i ><br clear=all >
-</i>
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-x-fees-collected.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-x-fees-collected.html.twig
@@ -76,6 +76,4 @@
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xia-number-times-subsection-c.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xia-number-times-subsection-c.html.twig
@@ -65,6 +65,4 @@
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xib-number-times-subsection-a2.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xib-number-times-subsection-a2.html.twig
@@ -78,5 +78,4 @@
 
 </div>
 
-<i ><br clear=all >
-</i>
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiia-backlogs.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiia-backlogs.html.twig
@@ -64,6 +64,4 @@
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiib-consultations.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiib-consultations.html.twig
@@ -89,6 +89,4 @@ RECEIVED, PROCESSED, AND PENDING CONSULTATIONS<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiic-consultations-ten-oldest.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiic-consultations-ten-oldest.html.twig
@@ -237,6 +237,4 @@ TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY<
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiid-comparisons-backlogged.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiid-comparisons-backlogged.html.twig
@@ -75,5 +75,4 @@ CURRENT ANNUAL REPORT -- BACKLOGGED REQUESTS<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiid-comparisons.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiid-comparisons.html.twig
@@ -94,6 +94,4 @@ REQUESTS RECEIVED AND PROCESSED<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiie-comparisons-appeals.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiie-comparisons-appeals.html.twig
@@ -106,6 +106,4 @@ ANNUAL REPORT -- APPEALS RECEIVED AND PROCESSED<o:p></o:p></b></p>
 
 </div>
 
-<i ><br clear=all >
-</i>
-
+<phpdocx_break data-type="page"></phpdocx_break>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiie2-comparisons-backlogged-appeals.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiie2-comparisons-backlogged-appeals.html.twig
@@ -68,16 +68,14 @@ ANNUAL REPORT -- BACKLOGGED APPEALS<o:p></o:p></b></p>
 
 <div class=WordSection98>
 
-<table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=535>
+<table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=535 >
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal ><i>{{ docx.field_footnotes_xiie2 }}</i><o:p></o:p></p>
+  <td width=535 nowrap valign=bottom >
+  <p class=MsoNormal align=left ><i>
+  {{ docx.field_footnotes_xiie2 }}
+  </i><o:p></o:p></p>
   </td>
  </tr>
 </table>
 
 </div>
-
-<i ><br clear=all >
-</i>
-


### PR DESCRIPTION
- Requires phpdocx premium license to use extended HTML tags.
- Includes some unrelated presentational cleanup on the trailing XII.E.(2) footnote table.