### PR TITLE
FOIA-214: Perform autocalculations when annual report form is loaded.

### DIFF
--- a/docroot/modules/custom/foia_autocalc/js/autocalc-field.js
+++ b/docroot/modules/custom/foia_autocalc/js/autocalc-field.js
@@ -2,31 +2,19 @@
   Drupal.behaviors.autocalcFields = {
     attach: function attach() {
       var autocalcSettings = drupalSettings.foiaAutocalc.autocalcSettings;
-      // Bind event listeners for autocalculation.
       Object.keys(autocalcSettings).forEach(function(fieldName, fieldIndex) {
         var fieldSettings = autocalcSettings[fieldName];
         fieldSettings.forEach(function(fieldSetting) {
           var fieldSelector = convertToFieldSelector(fieldSetting);
           $(fieldSelector + ' input').each(function(index) {
+            // Calculate field on initial form load.
+            $(fieldSelector + ' input').each(function(index) {
+              calculateField(fieldName, fieldSettings);
+            });
+            // Bind event listeners to calculate field when input fields are changed.
             $(this).once(fieldSelector + '_' + fieldIndex + '_' + index).on('change', function() {
               calculateField(fieldName, fieldSettings);
             });
-          });
-        });
-      });
-      // Perform calculations on form load.
-      $(document).ready(function() {
-        Object.keys(autocalcSettings).forEach(function(fieldName, fieldIndex) {
-          var fieldSettings = autocalcSettings[fieldName];
-          fieldSettings.forEach(function(fieldSetting) {
-            var fieldSelector = convertToFieldSelector(fieldSetting);
-            var fieldInputValue = $(convertToFieldSelector(fieldName + ' input').val());
-            if (!fieldInputValue) {
-              debugger;
-              $(fieldSelector + ' input').each(function(index) {
-                calculateField(fieldName, fieldSettings);
-              });
-            }
           });
         });
       });

--- a/docroot/modules/custom/foia_autocalc/js/autocalc-field.js
+++ b/docroot/modules/custom/foia_autocalc/js/autocalc-field.js
@@ -2,6 +2,7 @@
   Drupal.behaviors.autocalcFields = {
     attach: function attach() {
       var autocalcSettings = drupalSettings.foiaAutocalc.autocalcSettings;
+      // Bind event listeners for autocalculation.
       Object.keys(autocalcSettings).forEach(function(fieldName, fieldIndex) {
         var fieldSettings = autocalcSettings[fieldName];
         fieldSettings.forEach(function(fieldSetting) {
@@ -10,6 +11,22 @@
             $(this).once(fieldSelector + '_' + fieldIndex + '_' + index).on('change', function() {
               calculateField(fieldName, fieldSettings);
             });
+          });
+        });
+      });
+      // Perform calculations on form load.
+      $(document).ready(function() {
+        Object.keys(autocalcSettings).forEach(function(fieldName, fieldIndex) {
+          var fieldSettings = autocalcSettings[fieldName];
+          fieldSettings.forEach(function(fieldSetting) {
+            var fieldSelector = convertToFieldSelector(fieldSetting);
+            var fieldInputValue = $(convertToFieldSelector(fieldName + ' input').val());
+            if (!fieldInputValue) {
+              debugger;
+              $(fieldSelector + ' input').each(function(index) {
+                calculateField(fieldName, fieldSettings);
+              });
+            }
           });
         });
       });


### PR DESCRIPTION
After an initial attempt to limit the calculations to empty fields, I decided to keep the code simpler and I haven't observed much of a performance impact.