### PR TITLE
Foia 231 docx footnote width

### DIFF
--- a/docroot/modules/custom/node_to_docx/templates/docx-iv-exemption-3-statutes.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-iv-exemption-3-statutes.html.twig
@@ -89,7 +89,7 @@
 {% for key,value in docx.field_footnotes_iv if key|first != '#' %}
  <tr >
   <td width=570 nowrap valign=bottom >
-  <p class=MsoNormal align=left <i >
+  <p class=MsoNormal align=left><i >
   {{ docx.field_footnotes_iv[key] }}
   <o:p></o:p></i></p>
   </td>

--- a/docroot/modules/custom/node_to_docx/templates/docx-ix-foia-personnel-costs.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-ix-foia-personnel-costs.html.twig
@@ -123,8 +123,8 @@
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal ><i>{{ docx.field_footnotes_ix }}</i><o:p></o:p></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i>{{ docx.field_footnotes_ix }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-va-foia-requests.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-va-foia-requests.html.twig
@@ -100,7 +100,7 @@ AND PENDING FOIA REQUESTS<o:p></o:p></b></p>
 {% for key,value in docx.field_footnotes_va if key|first != '#' %}
  <tr >
   <td width=570 nowrap valign=bottom >
-  <p class=MsoNormal align=left <i >
+  <p class=MsoNormal align=left><i >
   {{ docx.field_footnotes_va[key] }}
   <o:p></o:p></i></p>
   </td>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vb3-disposition-number-of-times.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vb3-disposition-number-of-times.html.twig
@@ -197,7 +197,7 @@ DISPOSITION OF FOIA REQUESTS -- NUMBER OF TIMES EXEMPTIONS APPLIED<o:p></o:p></b
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
  <td width=570 nowrap valign=bottom >
-  <p class=MsoNormal align=center ><i>{{ docx.field_footnotes_vb3 }}</i><o:p></o:p></p>
+  <p class=MsoNormal align=left ><i>{{ docx.field_footnotes_vb3 }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vb3-disposition-number-of-times.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vb3-disposition-number-of-times.html.twig
@@ -196,7 +196,7 @@ DISPOSITION OF FOIA REQUESTS -- NUMBER OF TIMES EXEMPTIONS APPLIED<o:p></o:p></b
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
+ <td width=570 nowrap valign=bottom >
   <p class=MsoNormal align=center ><i>{{ docx.field_footnotes_vb3 }}</i><o:p></o:p></p>
   </td>
  </tr>

--- a/docroot/modules/custom/node_to_docx/templates/docx-via-administrative-appeals.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-via-administrative-appeals.html.twig
@@ -95,8 +95,8 @@ ADMINISTRATIVE APPEALS<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal><i >
+  <td width=570 nowrap valign=bottom >
+  <p class=MsoNormal align=left><i >
   {{ docx.field_footnotes_via }}
   <o:p></o:p></i></p>
   </td>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vic3-reasons-other.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vic3-reasons-other.html.twig
@@ -83,8 +83,8 @@ REASONS FOR DENIAL ON APPEAL -- &quot;OTHER&quot; REASONS<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal><i >{{ docx.field_footnotes_vic3 }}</i><o:p></o:p></p>
+  <td width=570 nowrap valign=bottom >
+  <p class=MsoNormal align=left><i >{{ docx.field_footnotes_vic3 }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vic4-response-time.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vic4-response-time.html.twig
@@ -86,8 +86,8 @@ RESPONSE TIME FOR ADMINISTRATIVE APPEALS<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal><i >{{ docx.field_footnotes_vic4 }}</i><o:p></o:p></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_vic4 }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-vic5-ten-oldest-pending.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-vic5-ten-oldest-pending.html.twig
@@ -251,8 +251,8 @@ OLDEST PENDING ADMINISTRATIVE APPEALS<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td nowrap valign=bottom >
-  <p class=MsoNormal><i >{{ docx.field_footnotes_vic5  }}</i><o:p></o:p></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_vic5  }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viia-response-time.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viia-response-time.html.twig
@@ -185,8 +185,8 @@ ALL PROCESSED PERFECTED REQUESTS<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal><i >{{ docx.field_footnotes_viia }}</i><o:p></o:p></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_viia }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viib-processed-requests-response-time.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viib-processed-requests-response-time.html.twig
@@ -185,8 +185,8 @@ TIME FOR PERFECTED REQUESTS IN WHICH INFORMATION WAS GRANTED<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal><i >{{ docx.field_footnotes_viib }}<o:p></o:p></i></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_viib }}<o:p></o:p></i></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viic-processed-complex-ten-day.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viic-processed-complex-ten-day.html.twig
@@ -201,8 +201,8 @@ RESPONSE TIME IN DAY INCREMENTS<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <tdvalign=bottom >
-  <p class=MsoNormal ><i>{{ docx.field_footnotes_viic2 }}<o:p></o:p></i></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_viic2 }}<o:p></o:p></i></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viic-processed-expedited-ten-day.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viic-processed-expedited-ten-day.html.twig
@@ -199,8 +199,8 @@ EXPEDITED PROCESSING -- RESPONSE TIME IN DAY INCREMENTS<o:p></o:p></b></p>
 <div class=WordSection53>
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal ><i>{{ docx.field_footnotes_viic3 }}</i><o:p></o:p></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_viic3 }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viic-processed-simple-ten-day.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viic-processed-simple-ten-day.html.twig
@@ -201,8 +201,8 @@ RESPONSE TIME IN DAY INCREMENTS<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal ><i>{{ docx.field_footnotes_viic1 }}</i><o:p></o:p></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_viic1 }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viid-pending-requests.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viid-pending-requests.html.twig
@@ -151,8 +151,8 @@ PERFECTED REQUESTS<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal><i >{{ docx.field_footnotes_viid  }}</i><o:p></o:p></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_viid  }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viie-pending-requests-ten-oldest.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viie-pending-requests-ten-oldest.html.twig
@@ -250,7 +250,7 @@ PENDING PERFECTED REQUESTS<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td width=535 nowrap valign=bottom >
+  <td width=570 nowrap valign=bottom >
   <p class=MsoNormal><i >{{ docx.field_footnotes_viie }}</i><o:p></o:p></p>
   </td>
  </tr>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viiia-requests-expedited.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viiia-requests-expedited.html.twig
@@ -96,8 +96,8 @@
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <tdvalign=bottom >
-  <p class=MsoNormal ><i>{{ docx.field_footnotes_viiia }}</i><o:p></o:p></p>
+  <td width=570 nowrap valign=bottom >
+  <p class=MsoNormal align=left><i>{{ docx.field_footnotes_viiia }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-viiib-requests-fee-waiver.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-viiib-requests-fee-waiver.html.twig
@@ -76,8 +76,8 @@
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal ><i>{{ docx.field_footnotes_viiib }}</i><o:p></o:p></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_viiib }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-x-fees-collected.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-x-fees-collected.html.twig
@@ -68,8 +68,8 @@
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal ><i>{{ docx.field_footnotes_x }}</i><o:p></o:p></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_x }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xia-number-times-subsection-c.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xia-number-times-subsection-c.html.twig
@@ -57,8 +57,8 @@
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=535>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal >{{ docx.field_footnotes_xia }}<i><o:p></o:p></i></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_xia }}<i><o:p></o:p></i></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xib-number-times-subsection-a2.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xib-number-times-subsection-a2.html.twig
@@ -70,8 +70,8 @@
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=535>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal ><i>{{ docx.field_footnotes_xib }}<o:p></o:p></i></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_xib }}<o:p></o:p></i></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiia-backlogs.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiia-backlogs.html.twig
@@ -56,7 +56,7 @@
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=535>
  <tr >
-  <td width=535 nowrap valign=bottom >
+  <td width=570 nowrap valign=bottom >
   <p class=MsoNormal align=center ><i>{{ docx.field_footnotes_xiia }}<o:p></o:p></i></p>
   </td>
  </tr>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiia-backlogs.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiia-backlogs.html.twig
@@ -57,7 +57,7 @@
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=535>
  <tr >
   <td width=570 nowrap valign=bottom >
-  <p class=MsoNormal align=center ><i>{{ docx.field_footnotes_xiia }}<o:p></o:p></i></p>
+  <p class=MsoNormal align=left ><i>{{ docx.field_footnotes_xiia }}<o:p></o:p></i></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiib-consultations.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiib-consultations.html.twig
@@ -81,8 +81,8 @@ RECEIVED, PROCESSED, AND PENDING CONSULTATIONS<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=535>
  <tr >
-  <td width=535 valign=bottom >
-  <p class=MsoNormal><i >{{ docx.field_footnotes_xiib }}<o:p></o:p></i></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_xiib }}<o:p></o:p></i></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiic-consultations-ten-oldest.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiic-consultations-ten-oldest.html.twig
@@ -229,8 +229,8 @@ TEN OLDEST CONSULTATIONS RECEIVED FROM OTHER AGENCIES AND PENDING AT THE AGENCY<
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal><i >{{ docx.field_footnotes_xiic }}<o:p></o:p></i></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_xiic }}<o:p></o:p></i></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiid-comparisons-backlogged.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiid-comparisons-backlogged.html.twig
@@ -67,8 +67,8 @@ CURRENT ANNUAL REPORT -- BACKLOGGED REQUESTS<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal ><i>{{ docx.field_footnotes_xiid2 }}</i><o:p></o:p></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_xiid2 }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiid-comparisons.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiid-comparisons.html.twig
@@ -87,7 +87,7 @@ REQUESTS RECEIVED AND PROCESSED<o:p></o:p></b></p>
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=535>
  <tr >
   <td width=570 nowrap valign=bottom >
-  <p class=MsoNormal align=center ><i>{{ docx.field_footnotes_xiid1 }}</i><o:p></o:p></p>
+  <p class=MsoNormal align=left ><i>{{ docx.field_footnotes_xiid1 }}</i><o:p></o:p></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiid-comparisons.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiid-comparisons.html.twig
@@ -86,7 +86,7 @@ REQUESTS RECEIVED AND PROCESSED<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=535>
  <tr >
-  <td width=535 nowrap valign=bottom >
+  <td width=570 nowrap valign=bottom >
   <p class=MsoNormal align=center ><i>{{ docx.field_footnotes_xiid1 }}</i><o:p></o:p></p>
   </td>
  </tr>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiie-comparisons-appeals.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiie-comparisons-appeals.html.twig
@@ -98,8 +98,8 @@ ANNUAL REPORT -- APPEALS RECEIVED AND PROCESSED<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=570>
  <tr >
-  <td valign=bottom >
-  <p class=MsoNormal ><i>{{ docx.field_footnotes_xiie1 }}<o:p></o:p></i></p>
+   <td width=570 nowrap valign=bottom >
+   <p class=MsoNormal align=left><i >{{ docx.field_footnotes_xiie1 }}<o:p></o:p></i></p>
   </td>
  </tr>
 </table>

--- a/docroot/modules/custom/node_to_docx/templates/docx-xiie2-comparisons-backlogged-appeals.html.twig
+++ b/docroot/modules/custom/node_to_docx/templates/docx-xiie2-comparisons-backlogged-appeals.html.twig
@@ -70,7 +70,7 @@ ANNUAL REPORT -- BACKLOGGED APPEALS<o:p></o:p></b></p>
 
 <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=535 >
  <tr >
-  <td width=535 nowrap valign=bottom >
+  <td width=570 nowrap valign=bottom >
   <p class=MsoNormal align=left ><i>
   {{ docx.field_footnotes_xiie2 }}
   </i><o:p></o:p></p>


### PR DESCRIPTION
* Fixes footnote table cell widths in docx templates for footnote cells that don't have a width set.
* Fixes broken markup in docx templates
* Normalizes footnote table cell widths to 570
* Standardizes footnote text alignment.