### PR TITLE
FOIA-126 validation (and advanced autocalc) code cleanup

### DIFF
--- a/docroot/modules/custom/foia_advcalc/foia_advcalc.info.yml
+++ b/docroot/modules/custom/foia_advcalc/foia_advcalc.info.yml
@@ -3,3 +3,5 @@ type: module
 description: Allows specific fields to be automatically calculated using custom calculations.
 package: FOIA
 core: 8.x
+dependencies:
+  - foia_ui

--- a/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
+++ b/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
@@ -32,7 +32,7 @@
        * @param {string} overallFieldID
        *    The calculated overall field HTML fragment ID.
        * @param {string} operator
-       *    The operation to be performed, "<", ">", or "+".
+       *    The operation to be performed, "<" or ">".
        */
       function calcOverall(componentId, componentFieldName, overallFieldID, operator) {
         var ops = {

--- a/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
+++ b/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
@@ -3,23 +3,9 @@
     attach: function attach() {
 
       /**
-       * Converts value to number and "N/A", "n/a", and "<1" values to 0.
-       *
-       * @param value
-       * @returns {number}
+       * Alias for Drupal.FoiaUI.specialNumber() utility function
        */
-      function specialNumber(value) {
-        switch (String(value).toLowerCase()) {
-          case "n/a":
-            return Number(0);
-            break;
-          case "<1":
-            return Number(0.1);
-            break;
-          default:
-            return Number(value);
-        }
-      }
+      var specialNumber = Drupal.FoiaUI.specialNumber;
 
      /**
        * Converts number back to "<1" if between 0 and 1.

--- a/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
+++ b/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
@@ -7,7 +7,7 @@
        */
       var specialNumber = Drupal.FoiaUI.specialNumber;
 
-     /**
+      /**
        * Converts number back to "<1" if between 0 and 1.
        *
        * @param {number}

--- a/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
+++ b/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
@@ -1,4 +1,13 @@
+/**
+ * @file
+ * Automatically calculate total fields with non-trivial summation.
+ * See foia_autocalc module for simple sum auto-calculations.
+ */
+
 (function ($, drupalSettings, Drupal) {
+
+  'use strict';
+
   Drupal.behaviors.advcalc_field = {
     attach: function attach() {
 
@@ -46,7 +55,7 @@
             var output = null;
             var isOverallNA = true;
             fields.each(function () {
-              value = $(this).val();
+              var value = $(this).val();
               if (String(value).toLowerCase() != 'n/a') {
                 isOverallNA = false;
                 if (value != '' && value !== null && (output == null || output == "n/a")) {
@@ -216,7 +225,7 @@
       });
 
       // Fields from IX and X to calculate field_perc_costs per agency.
-      //FOIA Personnel and Costs IX. proc_costs / Fees X. total_fees  = Fees X. perc_costs
+      // FOIA Personnel and Costs IX. proc_costs / Fees X. total_fees  = Fees X. perc_costs
       // If section IX proc_costs field changes.
       $( "input[name*='field_foia_pers_costs_ix']").filter("input[name*='field_proc_costs']").each(function() {
         $(this).once('advCalcIXProcCosts').change(function() {

--- a/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
+++ b/docroot/modules/custom/foia_advcalc/js/advcalc-field.js
@@ -3,9 +3,10 @@
     attach: function attach() {
 
       /**
-       * Alias for Drupal.FoiaUI.specialNumber() utility function
+       * Alias Drupal.FoiaUI utility functions
        */
       var specialNumber = Drupal.FoiaUI.specialNumber;
+      var getAgencyComponent = Drupal.FoiaUI.getAgencyComponent;
 
       /**
        * Converts number back to "<1" if between 0 and 1.
@@ -252,11 +253,6 @@
           $(perc_costs).val(perc_costs_val);
           return perc_costs;
         }
-      }
-
-      // Gets agency_component field for given field.
-      function getAgencyComponent(changed) {
-        return $(changed).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
       }
 
       // Get input field based on changed field ID and agency_component value.

--- a/docroot/modules/custom/foia_ui/foia_ui.libraries.yml
+++ b/docroot/modules/custom/foia_ui/foia_ui.libraries.yml
@@ -25,3 +25,7 @@ foia_ui_admin:
     js/foia_ui.admin.js: {}
   dependencies:
     - core/drupal.tabledrag
+
+foia_ui_utility:
+  js:
+    js/foia_ui.utility.js: {}

--- a/docroot/modules/custom/foia_ui/foia_ui.module
+++ b/docroot/modules/custom/foia_ui/foia_ui.module
@@ -61,6 +61,7 @@ function foia_ui_form_node_form_alter(&$form, FormStateInterface $form_state, $f
           'foia_ui/jquery_validation',
           'foia_ui/foia_ui_validation',
           'foia_ui/foia_ui_admin',
+          'foia_ui/foia_ui_utility',
         ],
         'drupalSettings' => [
           'foiaUI' => [

--- a/docroot/modules/custom/foia_ui/js/foia_ui.utility.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.utility.js
@@ -1,0 +1,43 @@
+/**
+ * @file
+ * Utility functions for FOIA admin UI.
+ */
+
+(function ($, drupalSettings) {
+
+  'use strict';
+
+  /**
+   * Converts value to number and "N/A", "n/a", and "<1" values to 0.
+   *
+   * @param value
+   * @returns {number}
+   */
+  Drupal.FoiaUI = {
+    specialNumber: function (value) {
+      switch (String(value).toLowerCase()) {
+        case "n/a":
+          return Number(0);
+          break;
+        case "<1":
+          return Number(0.1);
+          break;
+        default:
+          return Number(value);
+      }
+    },
+
+    /**
+     * Gets Agency/Component field value for a given field.
+     *
+     * @param {jQuery} changed
+     *   A jQuery object of the changed field
+     * @returns {string}
+     *   The related select value of field_agency_component.
+     */
+    getAgencyComponent: function (changed) {
+      return $(changed).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+    }
+  }
+
+})(jQuery, drupalSettings);

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -5,41 +5,6 @@
 
  (function ($, drupalSettings, Drupal) {
 
-  'use strict';
-
-  /**
-   * Converts value to number and "N/A", "n/a", and "<1" values to 0.
-   *
-   * @param value
-   * @returns {number}
-   */
-  Drupal.FoiaUI = {
-    specialNumber: function (value) {
-      switch (String(value).toLowerCase()) {
-        case "n/a":
-          return Number(0);
-          break;
-        case "<1":
-          return Number(0.1);
-          break;
-        default:
-          return Number(value);
-      }
-    },
-
-    /**
-     * Gets Agency/Component field value for a given field.
-     *
-     * @param {jQuery} changed
-     *   A jQuery object of the changed field
-     * @returns {string}
-     *   The related select value of field_agency_component.
-     */
-    getAgencyComponent: function (changed) {
-      return $(changed).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
-    }
-  }
-
   Drupal.behaviors.foia_ui_validation = {
     attach: function attach() {
       jQuery.validator.setDefaults({

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -138,27 +138,16 @@
        */
       // lessThanEqualTo
       $.validator.addMethod( "lessThanEqualTo", function( value, element, param ) {
-        var target = $( param );
-        return value <= Number(target.val());
-      }, "Please enter a lesser value." );
-
-      // lessThanEqualToNA
-      $.validator.addMethod( "lessThanEqualToNA", function( value, element, param ) {
-        var target = specialNumber($( param ).val());
         value = specialNumber(value);
+        var target = specialNumber($( param ).val());
         return value <= target;
       }, "Please enter a lesser value." );
 
        // greaterThanEqualTo
       $.validator.addMethod( "greaterThanEqualTo", function( value, element, param ) {
-        var target = $( param );
-        return value >= target.val();
-      }, "Please enter a greater value." );
-
-       // greaterThanEqualToNA
-      $.validator.addMethod( "greaterThanEqualToNA", function( value, element, param ) {
-        var target = specialNumber($( param ));
-        return value >= specialNumber(target.val());
+        value = specialNumber(value);
+        var target = specialNumber($( param ).val());
+        return value >= target;
       }, "Please enter a greater value." );
 
        // greaterThanZero
@@ -777,19 +766,19 @@
 
       // VI.C.(4) - Agency Overall Lowest Number of Days
       $( "#edit-field-overall-vic4-low-num-days-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-overall-vic4-high-num-days-0-value",
+        lessThanEqualTo: "#edit-field-overall-vic4-high-num-days-0-value",
         greaterThanZeroOrNA: true,
         messages: {
-          lessThanEqualToNA: "Must be lower than or equal to the highest number of days."
+          lessThanEqualTo: "Must be lower than or equal to the highest number of days."
         }
       });
 
       // VI.C.(4) - Agency Overall Highest Number of Days
       $( "#edit-field-overall-vic4-high-num-days-0-value").rules( "add", {
-        greaterThanEqualToNA: "#edit-field-overall-vic4-low-num-days-0-value",
+        greaterThanEqualTo: "#edit-field-overall-vic4-low-num-days-0-value",
         greaterThanZeroOrNA: true,
         messages: {
-          greaterThanEqualToNA: "Must be greater than or equal to the lowest number of days."
+          greaterThanEqualTo: "Must be greater than or equal to the lowest number of days."
         }
       });
 
@@ -801,9 +790,9 @@
             inputId = "#edit-field-overall-vic5-num-day-" + i + "-0-value",
             comparisonId = "#edit-field-overall-vic5-num-day-" + (i - 1) + "-0-value";
         $(inputId).rules( "add", {
-          lessThanEqualToNA: $(comparisonId),
+          lessThanEqualTo: $(comparisonId),
           messages: {
-            lessThanEqualToNA: "This should be less than or equal to the number of days for <em>" + prior + "</em>."
+            lessThanEqualTo: "This should be less than or equal to the number of days for <em>" + prior + "</em>."
           }
         });
       }
@@ -835,9 +824,9 @@
       $('input[name^="field_proc_req_viia"]').filter("input[name*='subform']").filter("input[name*='field_sim_low']").each(function(index) {
         var comparison_input = $(this).attr('name').replace('field_sim_low', 'field_sim_high');
         $(this).rules("add", {
-          lessThanEqualToNA: $('input[name="' + comparison_input + '"]'),
+          lessThanEqualTo: $('input[name="' + comparison_input + '"]'),
           messages: {
-            lessThanEqualToNA: "This should be less than or equal to the number of days for Highest Number of Days.",
+            lessThanEqualTo: "This should be less than or equal to the number of days for Highest Number of Days.",
           }
         });
 
@@ -884,9 +873,9 @@
       $('input[name^="field_proc_req_viia"]').filter("input[name*='subform']").filter("input[name*='field_comp_low']").each(function(index) {
         var comparison_input = $(this).attr('name').replace('field_comp_low', 'field_comp_high');
         $(this).rules("add", {
-          lessThanEqualToNA: $('input[name="' + comparison_input + '"]'),
+          lessThanEqualTo: $('input[name="' + comparison_input + '"]'),
           messages: {
-            lessThanEqualToNA: "This should be less than or equal to the number of days for Highest Number of Days.",
+            lessThanEqualTo: "This should be less than or equal to the number of days for Highest Number of Days.",
           }
         });
 
@@ -925,9 +914,9 @@
       $('input[name^="field_proc_req_viia"]').filter("input[name*='subform']").filter("input[name*='field_exp_low']").each(function(index) {
         var comparison_input = $(this).attr('name').replace('field_exp_low', 'field_exp_high');
         $(this).rules("add", {
-          lessThanEqualToNA: $('input[name="' + comparison_input + '"]'),
+          lessThanEqualTo: $('input[name="' + comparison_input + '"]'),
           messages: {
-            lessThanEqualToNA: "This should be less than or equal to the number of days for Highest Number of Days.",
+            lessThanEqualTo: "This should be less than or equal to the number of days for Highest Number of Days.",
           }
         });
 
@@ -966,9 +955,9 @@
       $('input[name^="field_proc_req_viib"]').filter("input[name*='subform']").filter("input[name*='field_sim_low']").each(function(index) {
         var comparison_input = $(this).attr('name').replace('field_sim_low', 'field_sim_high');
         $(this).rules("add", {
-          lessThanEqualToNA: $('input[name="' + comparison_input + '"]'),
+          lessThanEqualTo: $('input[name="' + comparison_input + '"]'),
           messages: {
-            lessThanEqualToNA: "This should be less than or equal to the number of days for Highest Number of Days.",
+            lessThanEqualTo: "This should be less than or equal to the number of days for Highest Number of Days.",
           }
         });
 
@@ -1007,9 +996,9 @@
       $('input[name^="field_proc_req_viib"]').filter("input[name*='subform']").filter("input[name*='field_comp_low']").each(function(index) {
         var comparison_input = $(this).attr('name').replace('field_comp_low', 'field_comp_high');
         $(this).rules("add", {
-          lessThanEqualToNA: $('input[name="' + comparison_input + '"]'),
+          lessThanEqualTo: $('input[name="' + comparison_input + '"]'),
           messages: {
-            lessThanEqualToNA: "This should be less than or equal to the number of days for Highest Number of Days.",
+            lessThanEqualTo: "This should be less than or equal to the number of days for Highest Number of Days.",
           }
         });
 
@@ -1048,9 +1037,9 @@
       $('input[name^="field_proc_req_viib"]').filter("input[name*='subform']").filter("input[name*='field_exp_low']").each(function(index) {
         var comparison_input = $(this).attr('name').replace('field_exp_low', 'field_exp_high');
         $(this).rules("add", {
-          lessThanEqualToNA: $('input[name="' + comparison_input + '"]'),
+          lessThanEqualTo: $('input[name="' + comparison_input + '"]'),
           messages: {
-            lessThanEqualToNA: "This should be less than or equal to the number of days for Highest Number of Days.",
+            lessThanEqualTo: "This should be less than or equal to the number of days for Highest Number of Days.",
           }
         });
 
@@ -1139,9 +1128,9 @@
             inputId = "#edit-field-overall-viie-num-days-" + i + "-0-value",
             comparisonId = "#edit-field-overall-viie-num-days-" + (i - 1) + "-0-value";
         $(inputId).rules( "add", {
-          lessThanEqualToNA: $(comparisonId),
+          lessThanEqualTo: $(comparisonId),
           messages: {
-            lessThanEqualToNA: "This should be less than or equal to the number of days for <em>" + prior + "</em>."
+            lessThanEqualTo: "This should be less than or equal to the number of days for <em>" + prior + "</em>."
           }
         });
       }
@@ -1251,9 +1240,9 @@
 
       // XII.A. Agency Overall Number of Backlogged Appeals as of End of Fiscal Year
       $( "#edit-field-overall-xiia-back-app-end-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-overall-via-app-pend-endyr-0-value",
+        lessThanEqualTo: "#edit-field-overall-via-app-pend-endyr-0-value",
         messages: {
-          lessThanEqualToNA: "Must be equal to or less than VI.A.(1). Agency Overall Number of Appeals Pending as of End of Fiscal Year",
+          lessThanEqualTo: "Must be equal to or less than VI.A.(1). Agency Overall Number of Appeals Pending as of End of Fiscal Year",
         }
       });
 
@@ -1277,9 +1266,9 @@
             inputId = "#edit-field-overall-xiic-num-days-" + i + "-0-value",
             comparisonId = "#edit-field-overall-xiic-num-days-" + (i - 1) + "-0-value";
         $(inputId).rules( "add", {
-            lessThanEqualToNA: $(comparisonId),
+            lessThanEqualTo: $(comparisonId),
             messages: {
-              lessThanEqualToNA: "This should be less than or equal to the number of days for <em>" + prior + "</em>."
+              lessThanEqualTo: "This should be less than or equal to the number of days for <em>" + prior + "</em>."
             }
           });
       }

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -18,6 +18,17 @@
         default:
           return Number(value);
       }
+    },
+
+    /**
+     * Gets agency_component field for given field.
+     *
+     * @param changed
+     *   jQuery object
+     * @returns {jQuery object}
+     */
+    getAgencyComponent: function(changed) {
+      return $(changed).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
     }
   }
 
@@ -29,9 +40,10 @@
       });
 
       /**
-       * Alias for Drupal.FoiaUI.specialNumber() utility function
+       * Alias Drupal.FoiaUI utility functions
        */
       var specialNumber = Drupal.FoiaUI.specialNumber;
+      var getAgencyComponent = Drupal.FoiaUI.getAgencyComponent;
 
       /**
        * Added for ie11 compatability.
@@ -172,9 +184,9 @@
 
       // ifGreaterThanZeroComp
       jQuery.validator.addMethod("ifGreaterThanZeroComp", function(value, element, params) {
-        var elementAgencyComponent = $(element).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+        var elementAgencyComponent = getAgencyComponent(element);
         for (var i = 0; i < params.length; i++){
-          var paramAgencyComponent = $(params[i]).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+          var paramAgencyComponent = getAgencyComponent(params[i]);
           if (paramAgencyComponent == elementAgencyComponent) {
             var target = Number($( params[i] ).val());
           }
@@ -209,10 +221,10 @@
       jQuery.validator.addMethod("lessThanEqualSumComp", function(value, element, params) {
         value = specialNumber(value);
         var sum = 0;
-        var elementAgencyComponent = $(element).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+        var elementAgencyComponent = getAgencyComponent(element);
         for (var i = 0; i < params.length; i++){
           for (var j = 0; j < params[i].length; j++){
-            var paramAgencyComponent = $(params[i][j]).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+            var paramAgencyComponent = getAgencyComponent(params[i][j]);
             if (paramAgencyComponent == elementAgencyComponent) {
               sum += specialNumber($( params[i][j] ).val());
             }
@@ -230,9 +242,9 @@
           var sumElement = $(element).parents('.paragraphs-subform').find("input[name*='" + multiField + "']");
           sum += specialNumber($(sumElement).val());
         });
-        var elementAgencyComponent = $(element).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+        var elementAgencyComponent = getAgencyComponent(element);
         for (var i = 0; i < params.target.length; i++){
-          var paramAgencyComponent = $(params.target[i]).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+          var paramAgencyComponent = getAgencyComponent(params.target[i]);
           if (paramAgencyComponent == elementAgencyComponent) {
             target = specialNumber($( params.target[i] ).val());
           }
@@ -242,9 +254,9 @@
 
       // equalToComp
       jQuery.validator.addMethod("equalToComp", function(value, element, params) {
-        var elementAgencyComponent = $(element).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+        var elementAgencyComponent = getAgencyComponent(element);
         for (var i = 0; i < params.length; i++){
-          var paramAgencyComponent = $(params[i]).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+          var paramAgencyComponent = getAgencyComponent(params[i]);
           if (paramAgencyComponent == elementAgencyComponent) {
             var target = Number($( params[i] ).val());
             return this.optional(element) || value == target;
@@ -255,9 +267,9 @@
       // lessThanEqualComp
       jQuery.validator.addMethod("lessThanEqualComp", function(value, element, params) {
         value = specialNumber(value);
-        var elementAgencyComponent = $(element).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+        var elementAgencyComponent = getAgencyComponent(element);
         for (var i = 0; i < params.length; i++){
-          var paramAgencyComponent = $(params[i]).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+          var paramAgencyComponent = getAgencyComponent(params[i]);
           if (paramAgencyComponent == elementAgencyComponent) {
             var target = specialNumber($( params[i] ).val());
             return this.optional(element) || value <= target;
@@ -274,9 +286,9 @@
 
       // greaterThanEqualComp
       jQuery.validator.addMethod("greaterThanEqualComp", function(value, element, params) {
-        var elementAgencyComponent = $(element).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+        var elementAgencyComponent = getAgencyComponent(element);
         for (var i = 0; i < params.length; i++){
-          var paramAgencyComponent = $(params[i]).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+          var paramAgencyComponent = getAgencyComponent(params[i]);
           if (paramAgencyComponent == elementAgencyComponent) {
             var target = Number($( params[i] ).val());
             return this.optional(element) || value >= target;
@@ -285,10 +297,10 @@
       }, "Must be greater than or equal to a field.");
 
       jQuery.validator.addMethod("greaterThanEqualSumComp", function(value, element, params) {
-        var elementAgencyComponent = $(element).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+        var elementAgencyComponent = getAgencyComponent(element);
         var sum = 0;
         for (var i = 0; i < params.length; i++) {
-          var paramAgencyComponent = $(params[i]).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+          var paramAgencyComponent = getAgencyComponent(params[i]);
           if (paramAgencyComponent == elementAgencyComponent) {
             sum += Number($( params[i] ).val());
           }
@@ -367,12 +379,12 @@
 
       // greaterThanZeroSumComp
       jQuery.validator.addMethod("greaterThanZeroSumComp", function(value, element, params) {
-        var elementAgencyComponent = $(element).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+        var elementAgencyComponent = getAgencyComponent(element);
         var sum = 0;
         if (value > 0) {
           for (var i = 0; i < params.length; i++) {
             for (var j = 0; j < params[i].length; j++) {
-              var paramAgencyComponent = $(params[i][j]).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+              var paramAgencyComponent = getAgencyComponent(params[i][j]);
               if (paramAgencyComponent == elementAgencyComponent) {
                 sum += Number($(params[i][j]).val());
               }
@@ -388,27 +400,27 @@
       // vb1matchDispositionComp: hard-coded for V.B.(1)
       jQuery.validator.addMethod("vb1matchDispositionComp", function(value, element, params) {
         var allReqProcessedYr = $( "input[name*='field_foia_requests_va']").filter("input[name*='field_req_processed_yr']");
-        var elementAgencyComponent = $(element).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+        var elementAgencyComponent = getAgencyComponent(element);
         var reqProcessedYr = null;
         var otherField = null;
         var sumVIICTotals = 0;
 
         for (var i = 0; i < allReqProcessedYr.length; i++){
-          var paramAgencyComponent = $(allReqProcessedYr[i]).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+          var paramAgencyComponent = getAgencyComponent(allReqProcessedYr[i]);
           if (paramAgencyComponent == elementAgencyComponent) {
             var reqProcessedYr = Number($( allReqProcessedYr[i] ).val());
           }
         }
 
         for (var i = 0; i < params.viicn.length; i++){
-          var paramAgencyComponent = $(params.viicn[i]).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+          var paramAgencyComponent = getAgencyComponent(params.viicn[i]);
           if (paramAgencyComponent == elementAgencyComponent) {
             sumVIICTotals += Number($( params.viicn[i] ).val());
           }
         }
 
         for (var i = 0; i < params.otherField.length; i++){
-          var paramAgencyComponent = $(params.otherField[i]).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
+          var paramAgencyComponent = getAgencyComponent(params.otherField[i]);
           if (paramAgencyComponent == elementAgencyComponent) {
             otherField = Number($( params.otherField[i] ).val());
           }

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -1,4 +1,11 @@
-(function ($, drupalSettings, Drupal) {
+/**
+ * @file
+ * Provide client-side validation for FOIA Annual Report.
+ */
+
+ (function ($, drupalSettings, Drupal) {
+
+  'use strict';
 
   /**
    * Converts value to number and "N/A", "n/a", and "<1" values to 0.
@@ -21,11 +28,12 @@
     },
 
     /**
-     * Gets agency_component field for given field.
+     * Gets Agency/Component field value for a given field.
      *
-     * @param changed
-     *   jQuery object
-     * @returns {jQuery object}
+     * @param {jQuery} changed
+     *   A jQuery object of the changed field
+     * @returns {string}
+     *   The related select value of field_agency_component.
      */
     getAgencyComponent: function (changed) {
       return $(changed).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
@@ -813,7 +821,7 @@
       // For each Agency/Component, iterate over 2nd to 10th Oldest days
       // comparing the value to the one before it, e.g. value of 9th <= 8th.
       for (var i = 2; i <= 10; i++){
-        priorOrdinal = oldestOrdinal(i - 1);
+        var priorOrdinal = oldestOrdinal(i - 1);
         $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_" + i + "']").each(function () {
           $(this).rules( "add", {
             lessThanEqualOlderComp: 'field_num_days_' + String(i-1),

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -7,7 +7,7 @@
    * @returns {number}
    */
   Drupal.FoiaUI = {
-    specialNumber: function(value) {
+    specialNumber: function (value) {
       switch (String(value).toLowerCase()) {
         case "n/a":
           return Number(0);
@@ -27,7 +27,7 @@
      *   jQuery object
      * @returns {jQuery object}
      */
-    getAgencyComponent: function(changed) {
+    getAgencyComponent: function (changed) {
       return $(changed).parents('.paragraphs-subform').find("select[name*='field_agency_component']").val();
     }
   }
@@ -149,26 +149,26 @@
        * Custom validation methods
        */
       // lessThanEqualTo
-      $.validator.addMethod( "lessThanEqualTo", function( value, element, param ) {
+      $.validator.addMethod( "lessThanEqualTo", function (value, element, param ) {
         value = specialNumber(value);
         var target = specialNumber($( param ).val());
         return value <= target;
       }, "Please enter a lesser value." );
 
        // greaterThanEqualTo
-      $.validator.addMethod( "greaterThanEqualTo", function( value, element, param ) {
+      $.validator.addMethod( "greaterThanEqualTo", function (value, element, param ) {
         value = specialNumber(value);
         var target = specialNumber($( param ).val());
         return value >= target;
       }, "Please enter a greater value." );
 
        // greaterThanZero
-       $.validator.addMethod( "greaterThanZero", function( value, element, param ) {
+       $.validator.addMethod( "greaterThanZero", function (value, element, param ) {
         return value > 0;
       }, "Please enter a value greater than zero." );
 
        // greaterThanZeroOrNA
-       $.validator.addMethod( "greaterThanZeroOrNA", function( value, element, param ) {
+       $.validator.addMethod( "greaterThanZeroOrNA", function (value, element, param ) {
         switch (String(value).toLowerCase()) {
           case "n/a":
           case "<1":
@@ -178,12 +178,12 @@
       }, "Please enter a value greater than zero." );
 
       // notNegative
-      $.validator.addMethod( "notNegative", function( value, element, param ) {
+      $.validator.addMethod( "notNegative", function (value, element, param ) {
         return value >= 0;
       }, "Please enter zero or a positive number." );
 
       // ifGreaterThanZeroComp
-      jQuery.validator.addMethod("ifGreaterThanZeroComp", function(value, element, params) {
+      jQuery.validator.addMethod("ifGreaterThanZeroComp", function (value, element, params) {
         var elementAgencyComponent = getAgencyComponent(element);
         for (var i = 0; i < params.length; i++){
           var paramAgencyComponent = getAgencyComponent(params[i]);
@@ -200,7 +200,7 @@
       }, "Must be greater than or equal to a field.");
 
       // equalSumComp
-      jQuery.validator.addMethod("equalSumComp", function(value, element, params) {
+      jQuery.validator.addMethod("equalSumComp", function (value, element, params) {
         var sum = 0;
         for (var i = 0; i < params.length; i++){
           sum += Number($( params[i] ).val());
@@ -209,16 +209,16 @@
       }, "Must equal sum of fields.");
 
       // lessThanEqualSum
-      jQuery.validator.addMethod("lessThanEqualSum", function(value, element, params) {
+      jQuery.validator.addMethod("lessThanEqualSum", function (value, element, params) {
         var sum = 0;
-        params.forEach(function(param) {
+        params.forEach(function (param) {
           sum += Number($(param).val());
         });
         return this.optional(element) || value <= sum;
       }, "Must equal less than equal a sum of other fields.");
 
       // lessThanEqualSumComp
-      jQuery.validator.addMethod("lessThanEqualSumComp", function(value, element, params) {
+      jQuery.validator.addMethod("lessThanEqualSumComp", function (value, element, params) {
         value = specialNumber(value);
         var sum = 0;
         var elementAgencyComponent = getAgencyComponent(element);
@@ -234,11 +234,11 @@
       }, "Must be less than or equal to a field.");
 
       // multiLessThanEqualSumComp
-      jQuery.validator.addMethod("multiLessThanEqualSumComp", function(value, element, params) {
+      jQuery.validator.addMethod("multiLessThanEqualSumComp", function (value, element, params) {
         value = specialNumber(value);
         var sum = 0;
         var target = 0;
-        params.multiFields.forEach(function(multiField) {
+        params.multiFields.forEach(function (multiField) {
           var sumElement = $(element).parents('.paragraphs-subform').find("input[name*='" + multiField + "']");
           sum += specialNumber($(sumElement).val());
         });
@@ -253,7 +253,7 @@
       }, "Sum of fields must be less than or equal to a field.");
 
       // equalToComp
-      jQuery.validator.addMethod("equalToComp", function(value, element, params) {
+      jQuery.validator.addMethod("equalToComp", function (value, element, params) {
         var elementAgencyComponent = getAgencyComponent(element);
         for (var i = 0; i < params.length; i++){
           var paramAgencyComponent = getAgencyComponent(params[i]);
@@ -265,7 +265,7 @@
       }, "Must be equal to a field.");
 
       // lessThanEqualComp
-      jQuery.validator.addMethod("lessThanEqualComp", function(value, element, params) {
+      jQuery.validator.addMethod("lessThanEqualComp", function (value, element, params) {
         value = specialNumber(value);
         var elementAgencyComponent = getAgencyComponent(element);
         for (var i = 0; i < params.length; i++){
@@ -278,14 +278,14 @@
       }, "Must be less than or equal to a field.");
 
       // lessThanEqualOlderComp
-      jQuery.validator.addMethod("lessThanEqualOlderComp", function(value, element, params) {
+      jQuery.validator.addMethod("lessThanEqualOlderComp", function (value, element, params) {
         value = specialNumber(value);
         var target = Number($(element).parents('.paragraphs-subform').find("input[name*='" + params + "']").val());
         return this.optional(element) || value <= target;
       }, "Must be less than or equal to a field.");
 
       // greaterThanEqualComp
-      jQuery.validator.addMethod("greaterThanEqualComp", function(value, element, params) {
+      jQuery.validator.addMethod("greaterThanEqualComp", function (value, element, params) {
         var elementAgencyComponent = getAgencyComponent(element);
         for (var i = 0; i < params.length; i++){
           var paramAgencyComponent = getAgencyComponent(params[i]);
@@ -296,7 +296,7 @@
         }
       }, "Must be greater than or equal to a field.");
 
-      jQuery.validator.addMethod("greaterThanEqualSumComp", function(value, element, params) {
+      jQuery.validator.addMethod("greaterThanEqualSumComp", function (value, element, params) {
         var elementAgencyComponent = getAgencyComponent(element);
         var sum = 0;
         for (var i = 0; i < params.length; i++) {
@@ -309,7 +309,7 @@
       }, "Must be greater than or equal to sum of the fields.");
 
       // betweenMinMaxCompNA
-      jQuery.validator.addMethod("betweenMinMaxCompNA", function(value, element, params) {
+      jQuery.validator.addMethod("betweenMinMaxCompNA", function (value, element, params) {
         value = specialNumber(value);
         var valuesArray = [];
         for (var i = 0; i < params.length; i++){
@@ -321,7 +321,7 @@
       }, "Must be between the smallest and largest values.");
 
       // equalToLowestComp
-      jQuery.validator.addMethod("equalToLowestComp", function(value, element, params) {
+      jQuery.validator.addMethod("equalToLowestComp", function (value, element, params) {
         value = specialNumber(value);
         var valuesArray = [];
         for (var i = 0; i < params.length; i++){
@@ -331,7 +331,7 @@
       }, "Must equal the lowest value.");
 
       // equalToHighestComp
-      jQuery.validator.addMethod("equalToHighestComp", function(value, element, params) {
+      jQuery.validator.addMethod("equalToHighestComp", function (value, element, params) {
         value = specialNumber(value);
         var valuesArray = [];
         for (var i = 0; i < params.length; i++){
@@ -367,7 +367,7 @@
       }, "Must be a valid date.");
 
       // notAverageCompNA
-      jQuery.validator.addMethod("notAverageCompNA", function(value, element, params) {
+      jQuery.validator.addMethod("notAverageCompNA", function (value, element, params) {
         value = specialNumber(value);
         var sum = 0;
         for (var i = 0; i < params.length; i++){
@@ -378,7 +378,7 @@
       }, "Must not be equal to the average.");
 
       // greaterThanZeroSumComp
-      jQuery.validator.addMethod("greaterThanZeroSumComp", function(value, element, params) {
+      jQuery.validator.addMethod("greaterThanZeroSumComp", function (value, element, params) {
         var elementAgencyComponent = getAgencyComponent(element);
         var sum = 0;
         if (value > 0) {
@@ -398,7 +398,7 @@
       }, "Sum of the fields must be greater than zero.");
 
       // vb1matchDispositionComp: hard-coded for V.B.(1)
-      jQuery.validator.addMethod("vb1matchDispositionComp", function(value, element, params) {
+      jQuery.validator.addMethod("vb1matchDispositionComp", function (value, element, params) {
         var allReqProcessedYr = $( "input[name*='field_foia_requests_va']").filter("input[name*='field_req_processed_yr']");
         var elementAgencyComponent = getAgencyComponent(element);
         var reqProcessedYr = null;
@@ -438,17 +438,17 @@
 
         // Show errors using the built in defaultShowErrors() method
         // and then highlight tabs all at once.
-        showErrors: function(errors) {
+        showErrors: function (errors) {
           this.defaultShowErrors();
           this.settings.highlightTabs();
         },
 
         // Highlight top level tabs only.
-        highlightTabs: function() {
+        highlightTabs: function () {
           // Gets only the top level of vertical tab menu items.
           var tabs = document.querySelector('.js-vertical-tabs--main > .vertical-tabs > .vertical-tabs__menu');
 
-          $('> .vertical-tabs__menu-item', tabs).each(function(index, menuItem) {
+          $('> .vertical-tabs__menu-item', tabs).each(function (index, menuItem) {
             try {
               var link = $('> a', menuItem).get(0),
                   tabId = link.getAttribute('href') || false;
@@ -485,7 +485,7 @@
             '</div></div>');
       }
 
-      $('input#edit-validate-button').once('foia-validation').on('click', function(event) {
+      $('input#edit-validate-button').once('foia-validation').on('click', function (event) {
         event.preventDefault();
 
         $('.validation-overlay').removeClass('hidden');
@@ -496,7 +496,7 @@
 
 
         // Allow some time for the overlay to render.
-        setTimeout(function() {
+        setTimeout(function () {
           // Validate form
           $(drupalSettings.foiaUI.foiaUISettings.formID).valid();
 
@@ -515,7 +515,7 @@
        * Note: All validation rules can be bypassed on submit.
        */
       // Require all Annual Report fields.
-      $(".form-text, .form-textarea, .form-select, .form-number, .form-date").not('#edit-revision-log-0-value').not('[readonly]').not('[id*="footnote"]').each(function() {
+      $(".form-text, .form-textarea, .form-select, .form-number, .form-date").not('#edit-revision-log-0-value').not('[readonly]').not('[id*="footnote"]').each(function () {
         $(this).rules( "add", {
         required: true,
         });
@@ -537,7 +537,7 @@
           });
 
        // V.A. FOIA Requests
-      $( "input[name*='field_foia_requests_va']").filter("input[name*='field_req_processed_yr']").each(function() {
+      $( "input[name*='field_foia_requests_va']").filter("input[name*='field_req_processed_yr']").each(function () {
         $(this).rules( "add", {
           equalToComp: $( "input[name*='field_foia_requests_vb1']").filter("input[name*='field_total']"),
           greaterThanEqualSumComp: $( "input[name*='field_proc_req_viic1']").filter("input[name*='field_total']")
@@ -559,7 +559,7 @@
       });
 
       // V.B.(1) Records Not Reasonably Described
-      $( "input[name*='field_foia_requests_vb1']").filter("input[name*='field_rec_not_desc']").each(function() {
+      $( "input[name*='field_foia_requests_vb1']").filter("input[name*='field_rec_not_desc']").each(function () {
         $(this).rules( "add", {
           vb1matchDispositionComp: {
             viicn: $( "input[name*='field_proc_req_viic1']").filter("input[name*='field_total']")
@@ -574,7 +574,7 @@
       });
 
       // V.B.(1) Improper FOIA Request for Other Reason
-      $( "input[name*='field_foia_requests_vb1']").filter("input[name*='field_imp_req_oth_reason']").each(function() {
+      $( "input[name*='field_foia_requests_vb1']").filter("input[name*='field_imp_req_oth_reason']").each(function () {
         $(this).rules( "add", {
           vb1matchDispositionComp: {
             viicn: $( "input[name*='field_proc_req_viic1']").filter("input[name*='field_total']")
@@ -629,7 +629,7 @@
       });
 
       // V.B.(1) Agency Component Other*
-      $( "input[name*='field_foia_requests_vb1']").filter("input[name*='field_oth']").each(function() {
+      $( "input[name*='field_foia_requests_vb1']").filter("input[name*='field_oth']").each(function () {
           $(this).rules( "add", {
               equalToComp: $("input[name*='field_foia_requests_vb2']").filter("input[name*='field_total']"),
               messages: {
@@ -639,7 +639,7 @@
       });
 
       // V.B.(1) Agency Number of Full Denials Based on Exemptions
-        $( "input[name*='field_foia_requests_vb1']").filter("input[name*='field_full_denials_ex']").each(function() {
+        $( "input[name*='field_foia_requests_vb1']").filter("input[name*='field_full_denials_ex']").each(function () {
           $(this).rules( "add", {
             lessThanEqualSumComp: [
               $("input[name*='field_foia_requests_vb3']").filter("input[name*='field_ex_1']"),
@@ -681,7 +681,7 @@
       });
 
       // VI.A. Administrative Appeals Processed During Fiscal Year from Current Annual Report
-      $( "input[name*='field_admin_app_via']").filter("input[name*='field_app_processed_yr']").each(function() {
+      $( "input[name*='field_admin_app_via']").filter("input[name*='field_app_processed_yr']").each(function () {
         $(this).rules( "add", {
           equalToComp: $( "input[name*='field_admin_app_vib']").filter("input[name*='field_total']"),
           messages: {
@@ -691,7 +691,7 @@
       });
 
       // VI.A. Agency Overall Number of Appeals Processed in Fiscal Year
-      $( "input[name*='field_admin_app_via']").filter("input[name*='field_app_pend_end_yr']").each(function() {
+      $( "input[name*='field_admin_app_via']").filter("input[name*='field_app_pend_end_yr']").each(function () {
         $(this).rules( "add", {
           greaterThanZeroSumComp: [
             $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_1']"),
@@ -712,7 +712,7 @@
       });
 
       // VI.B. Administrative Appeals
-      $( "input[name*='field_admin_app_vib']").filter("input[name*='field_closed_oth_app']").each(function() {
+      $( "input[name*='field_admin_app_vib']").filter("input[name*='field_closed_oth_app']").each(function () {
         $(this).rules( "add", {
           lessThanEqualComp: $("input[name*='field_admin_app_vic2']").filter("input[name*='field_oth']"),
           messages: {
@@ -750,7 +750,7 @@
       });
 
       // VI.C.2 Reasons for Denial on Appeal -- "Other" Reasons
-      $( "input[name*='field_admin_app_vic2']").filter("input[name*='field_oth']").each(function() {
+      $( "input[name*='field_admin_app_vic2']").filter("input[name*='field_oth']").each(function () {
         $(this).rules( "add", {
           equalToComp: $( "input[name*='field_admin_app_vic3']").filter("input[name*='field_total']"),
           messages: {
@@ -814,7 +814,7 @@
       // comparing the value to the one before it, e.g. value of 9th <= 8th.
       for (var i = 2; i <= 10; i++){
         priorOrdinal = oldestOrdinal(i - 1);
-        $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_" + i + "']").each(function() {
+        $("input[name*='field_admin_app_vic5']").filter("input[name*='field_num_days_" + i + "']").each(function () {
           $(this).rules( "add", {
             lessThanEqualOlderComp: 'field_num_days_' + String(i-1),
             messages: {
@@ -833,7 +833,7 @@
       });
 
       // VII.A. Simple - Agency Component Lowest Number of Days
-      $('input[name^="field_proc_req_viia"]').filter("input[name*='subform']").filter("input[name*='field_sim_low']").each(function(index) {
+      $('input[name^="field_proc_req_viia"]').filter("input[name*='subform']").filter("input[name*='field_sim_low']").each(function (index) {
         var comparison_input = $(this).attr('name').replace('field_sim_low', 'field_sim_high');
         $(this).rules("add", {
           lessThanEqualTo: $('input[name="' + comparison_input + '"]'),
@@ -844,7 +844,7 @@
 
         // Revalidate the lowest days value when the highest days value changes.
         var that = this;
-        $('input[name="' + comparison_input + '"]').once('VIIASimHighValidate').keyup(function(event) {
+        $('input[name="' + comparison_input + '"]').once('VIIASimHighValidate').keyup(function (event) {
           revalidateOnKeyup(event, that);
         })
       });
@@ -882,7 +882,7 @@
       });
 
       // VII.A. Complex - Agency Component Lowest Number of Days
-      $('input[name^="field_proc_req_viia"]').filter("input[name*='subform']").filter("input[name*='field_comp_low']").each(function(index) {
+      $('input[name^="field_proc_req_viia"]').filter("input[name*='subform']").filter("input[name*='field_comp_low']").each(function (index) {
         var comparison_input = $(this).attr('name').replace('field_comp_low', 'field_comp_high');
         $(this).rules("add", {
           lessThanEqualTo: $('input[name="' + comparison_input + '"]'),
@@ -893,7 +893,7 @@
 
         // Revalidate the lowest days value when the highest days value changes.
         var that = this;
-        $('input[name="' + comparison_input + '"]').once('VIIACompHighValidate').keyup(function(event) {
+        $('input[name="' + comparison_input + '"]').once('VIIACompHighValidate').keyup(function (event) {
           revalidateOnKeyup(event, that);
         })
       });
@@ -923,7 +923,7 @@
       });
 
       // VII.A. Expedited Processing - Agency Component Lowest Number of Days
-      $('input[name^="field_proc_req_viia"]').filter("input[name*='subform']").filter("input[name*='field_exp_low']").each(function(index) {
+      $('input[name^="field_proc_req_viia"]').filter("input[name*='subform']").filter("input[name*='field_exp_low']").each(function (index) {
         var comparison_input = $(this).attr('name').replace('field_exp_low', 'field_exp_high');
         $(this).rules("add", {
           lessThanEqualTo: $('input[name="' + comparison_input + '"]'),
@@ -934,7 +934,7 @@
 
         // Revalidate the lowest days value when the highest days value changes.
         var that = this;
-        $('input[name="' + comparison_input + '"]').once('VIIAExpHighValidate').keyup(function(event) {
+        $('input[name="' + comparison_input + '"]').once('VIIAExpHighValidate').keyup(function (event) {
           revalidateOnKeyup(event, that);
         })
       });
@@ -964,7 +964,7 @@
       });
 
       // VII.B. Simple - Agency Component Lowest Number of Days
-      $('input[name^="field_proc_req_viib"]').filter("input[name*='subform']").filter("input[name*='field_sim_low']").each(function(index) {
+      $('input[name^="field_proc_req_viib"]').filter("input[name*='subform']").filter("input[name*='field_sim_low']").each(function (index) {
         var comparison_input = $(this).attr('name').replace('field_sim_low', 'field_sim_high');
         $(this).rules("add", {
           lessThanEqualTo: $('input[name="' + comparison_input + '"]'),
@@ -975,7 +975,7 @@
 
         // Revalidate the lowest days value when the highest days value changes.
         var that = this;
-        $('input[name="' + comparison_input + '"]').once('VIIBSimHighValidate').keyup(function(event) {
+        $('input[name="' + comparison_input + '"]').once('VIIBSimHighValidate').keyup(function (event) {
           revalidateOnKeyup(event, that);
         })
       });
@@ -1005,7 +1005,7 @@
       });
 
       // VII.B. Complex - Agency Component Lowest Number of Days
-      $('input[name^="field_proc_req_viib"]').filter("input[name*='subform']").filter("input[name*='field_comp_low']").each(function(index) {
+      $('input[name^="field_proc_req_viib"]').filter("input[name*='subform']").filter("input[name*='field_comp_low']").each(function (index) {
         var comparison_input = $(this).attr('name').replace('field_comp_low', 'field_comp_high');
         $(this).rules("add", {
           lessThanEqualTo: $('input[name="' + comparison_input + '"]'),
@@ -1016,7 +1016,7 @@
 
         // Revalidate the lowest days value when the highest days value changes.
         var that = this;
-        $('input[name="' + comparison_input + '"]').once('VIIBCompHighValidate').keyup(function(event) {
+        $('input[name="' + comparison_input + '"]').once('VIIBCompHighValidate').keyup(function (event) {
           revalidateOnKeyup(event, that);
         })
       });
@@ -1046,7 +1046,7 @@
       });
 
       // VII.B. Expedited Processing - Agency Component Lowest Number of Days
-      $('input[name^="field_proc_req_viib"]').filter("input[name*='subform']").filter("input[name*='field_exp_low']").each(function(index) {
+      $('input[name^="field_proc_req_viib"]').filter("input[name*='subform']").filter("input[name*='field_exp_low']").each(function (index) {
         var comparison_input = $(this).attr('name').replace('field_exp_low', 'field_exp_high');
         $(this).rules("add", {
           lessThanEqualTo: $('input[name="' + comparison_input + '"]'),
@@ -1057,7 +1057,7 @@
 
         // Revalidate the lowest days value when the highest days value changes.
         var that = this;
-        $('input[name="' + comparison_input + '"]').once('VIIBExpHighValidate').keyup(function(event) {
+        $('input[name="' + comparison_input + '"]').once('VIIBExpHighValidate').keyup(function (event) {
           revalidateOnKeyup(event, that);
         })
       });
@@ -1072,7 +1072,7 @@
 
       // VII.D. Sum of requests in simple, complex, and expedited must be equal
       // to or less than number of requests pending at end of FY from V.A
-      $("input[name*='field_pending_requests_vii_d_']").filter("input[name*='field_sim_pend'], input[name*='field_comp_pend'], input[name*='field_exp_pend']").each(function() {
+      $("input[name*='field_pending_requests_vii_d_']").filter("input[name*='field_sim_pend'], input[name*='field_comp_pend'], input[name*='field_exp_pend']").each(function () {
         $(this).rules( "add", {
           multiLessThanEqualSumComp: {
             multiFields: ['field_sim_pend', 'field_comp_pend', 'field_exp_pend'],
@@ -1152,7 +1152,7 @@
       // comparing the value to the one before it, e.g. value of 9th <= 8th.
       for (var i = 2; i <= 10; i++){
         priorOrdinal = oldestOrdinal(i - 1);
-        $("input[name*='field_admin_app_viie']").filter("input[name*='field_num_days_" + i + "']").each(function() {
+        $("input[name*='field_admin_app_viie']").filter("input[name*='field_num_days_" + i + "']").each(function () {
           $(this).rules( "add", {
             lessThanEqualOlderComp: 'field_num_days_' + String(i-1),
             messages: {
@@ -1190,7 +1190,7 @@
       });
 
       // IX. Total Number of "Full-Time FOIA Staff"
-      $("input[name*='field_foia_pers_costs_ix']").filter("input[name*='field_total_staff']").each(function() {
+      $("input[name*='field_foia_pers_costs_ix']").filter("input[name*='field_total_staff']").each(function () {
         $(this).rules( "add", {
           ifGreaterThanZeroComp: $("input[name*='field_foia_requests_vb1']").filter("input[name*='field_total']"),
           messages: {
@@ -1201,10 +1201,10 @@
 
       // IX. Agency Overall Total Number of "Full-Time FOIA Staff"
       // IX. Agency Overall Processing Costs
-      $( "#edit-field-overall-ix-total-staff-0-value, #edit-field-overall-ix-total-costs-0-value").each(function() {
+      $( "#edit-field-overall-ix-total-staff-0-value, #edit-field-overall-ix-total-costs-0-value").each(function () {
         $(this).rules( "add", {
           greaterThanZero: {
-            depends: function() {
+            depends: function () {
               return Number($("#edit-field-overall-vb1-total-0-value").val()) > 0;
             }
           },
@@ -1215,7 +1215,7 @@
       });
 
       // XII.A. Number of Backlogged Requests as of End of Fiscal Year
-      $( "input[name*='field_foia_xiia']").filter("input[name*='field_back_req_end_yr']").each(function() {
+      $( "input[name*='field_foia_xiia']").filter("input[name*='field_back_req_end_yr']").each(function () {
         $(this).rules( "add", {
           lessThanEqualSumComp: [
             $("input[name*='field_pending_requests_vii_d_']").filter("input[name*='field_sim_pend']"),
@@ -1229,7 +1229,7 @@
       });
 
       // XII.A. Number of Backlogged Appeals as of End of Fiscal Year
-      $( "input[name*='field_foia_xiia']").filter("input[name*='field_back_app_end_yr']").each(function() {
+      $( "input[name*='field_foia_xiia']").filter("input[name*='field_back_app_end_yr']").each(function () {
         $(this).rules( "add", {
           lessThanEqualComp: $("input[name*='field_admin_app_via']").filter("input[name*='field_app_pend_end_yr']"),
           messages: {
@@ -1290,7 +1290,7 @@
       // comparing the value to the one before it, e.g. value of 9th <= 8th.
       for (var i = 2; i <= 10; i++){
         priorOrdinal = oldestOrdinal(i - 1);
-        $("input[name*='field_foia_xiic']").filter("input[name*='field_num_days_" + i + "']").each(function() {
+        $("input[name*='field_foia_xiic']").filter("input[name*='field_num_days_" + i + "']").each(function () {
           $(this).rules( "add", {
             lessThanEqualOlderComp: 'field_num_days_' + String(i-1),
             messages: {
@@ -1301,7 +1301,7 @@
       }
 
       // XII.D.(1). Number Received During Fiscal Year from Current Annual Report
-      $( "input[name*='field_foia_xiid1']").filter("input[name*='field_received_cur_yr']").each(function() {
+      $( "input[name*='field_foia_xiid1']").filter("input[name*='field_received_cur_yr']").each(function () {
         $(this).rules( "add", {
           equalToComp: $( "input[name*='field_foia_requests_va']").filter("input[name*='field_req_received_yr']"),
           messages: {
@@ -1311,7 +1311,7 @@
       });
 
       // XII.D.(1). Number Processed During Fiscal Year from Current Annual Report
-      $( "input[name*='field_foia_xiid1']").filter("input[name*='field_proc_cur_yr']").each(function() {
+      $( "input[name*='field_foia_xiid1']").filter("input[name*='field_proc_cur_yr']").each(function () {
         $(this).rules( "add", {
           equalToComp: $( "input[name*='field_foia_requests_va']").filter("input[name*='field_req_processed_yr']"),
           messages: {
@@ -1337,7 +1337,7 @@
       });
 
       // XII.D.(2). Number of Backlogged Requests as of End of the Fiscal Year from Current Annual Report
-      $( "input[name*='field_foia_xiid2']").filter("input[name*='field_back_cur_yr']").each(function() {
+      $( "input[name*='field_foia_xiid2']").filter("input[name*='field_back_cur_yr']").each(function () {
         $(this).rules( "add", {
           equalToComp: $( "input[name*='field_foia_xiia']").filter("input[name*='field_back_req_end_yr']"),
           messages: {
@@ -1355,7 +1355,7 @@
       });
 
       // XII.E.(1). Number Received During Fiscal Year from Current Annual Report
-      $( "input[name*='field_foia_xiie1']").filter("input[name*='field_received_cur_yr']").each(function() {
+      $( "input[name*='field_foia_xiie1']").filter("input[name*='field_received_cur_yr']").each(function () {
         $(this).rules( "add", {
           equalToComp: $( "input[name*='field_admin_app_via']").filter("input[name*='field_app_received_yr']"),
           messages: {
@@ -1365,7 +1365,7 @@
       });
 
       // XII.E.(1). Number Processed During Fiscal Year from Current Annual Report
-      $( "input[name*='field_foia_xiie1']").filter("input[name*='field_proc_cur_yr']").each(function() {
+      $( "input[name*='field_foia_xiie1']").filter("input[name*='field_proc_cur_yr']").each(function () {
         $(this).rules( "add", {
           equalToComp: $( "input[name*='field_admin_app_via']").filter("input[name*='field_app_processed_yr']"),
           messages: {
@@ -1391,7 +1391,7 @@
       });
 
       // XII.E.(2). Number Processed During Fiscal Year from Current Annual Report
-      $( "input[name*='field_foia_xiie2']").filter("input[name*='field_back_cur_yr']").each(function() {
+      $( "input[name*='field_foia_xiie2']").filter("input[name*='field_back_cur_yr']").each(function () {
         $(this).rules( "add", {
           equalToComp: $( "input[name*='field_foia_xiia']").filter("input[name*='field_back_app_end_yr']"),
           messages: {


### PR DESCRIPTION
- Refactors and consolidates code use across `foia_ui.validate.js` and `advcalc-field.js`.
- Enables strict mode
- Updates and improves documentation
- Some whitespace cleanup

Note that after rewriting the _for i_ loops on object collections with Object.keys.forEach(), I ran encountered errors with the final item in the array and I did not find that the code was more readable, so I opted to keep the initial _for i_ loop approach.