### PR TITLE
FOIA-126 Remove obsolete validation on VI.C(4), VII.A., and VII.B.

### DIFF
--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -875,14 +875,6 @@
         }
       });
 
-      // VII.B. Simple - Agency Overall Lowest Number of Days
-      $( "#edit-field-overall-viib-sim-low-0-value").rules( "add", {
-        equalToLowestComp: $("input[name*='field_proc_req_viib']").filter("input[name*='field_sim_low']"),
-        messages: {
-          equalToLowestComp: "Must equal smallest value of Lowest number of days."
-        }
-      });
-
       // VII.B. Simple - Agency Component Lowest Number of Days
       $('input[name^="field_proc_req_viib"]').filter("input[name*='subform']").filter("input[name*='field_sim_low']").each(function(index) {
         var comparison_input = $(this).attr('name').replace('field_sim_low', 'field_sim_high');
@@ -900,27 +892,11 @@
         })
       });
 
-      // VII.B. Simple - Agency Overall Highest Number of Days
-      $( "#edit-field-overall-viib-sim-high-0-value").rules( "add", {
-        equalToHighestComp: $("input[name*='field_proc_req_viib']").filter("input[name*='field_sim_high']"),
-        messages: {
-          equalToHighestComp: "Must equal largest value of Highest number of days."
-        }
-      });
-
       // VII.B. Complex - Agency Overall Median Number of Days
       $( "#edit-field-overall-viib-comp-med-0-value").rules( "add", {
         betweenMinMaxCompNA: $("input[name*='field_proc_req_viib']").filter("input[name*='field_comp_med']"),
         messages: {
           betweenMinMaxCompNA: "This field should be between the largest and smallest values of Median Number of Days"
-        }
-      });
-
-      // VII.B. Complex - Agency Overall Lowest Number of Days
-      $( "#edit-field-overall-viib-comp-low-0-value").rules( "add", {
-        equalToLowestComp: $("input[name*='field_proc_req_viib']").filter("input[name*='field_comp_low']"),
-        messages: {
-          equalToLowestComp: "Must equal smallest value of Lowest number of days."
         }
       });
 
@@ -941,27 +917,11 @@
         })
       });
 
-      // VII.B. Complex - Agency Overall Highest Number of Days
-      $( "#edit-field-overall-viib-comp-high-0-value").rules( "add", {
-        equalToHighestComp: $("input[name*='field_proc_req_viib']").filter("input[name*='field_comp_high']"),
-        messages: {
-          equalToHighestComp: "Must equal largest value of Highest number of days."
-        }
-      });
-
       // VII.B. Expedited Processing - Agency Overall Median Number of Days
       $( "#edit-field-overall-viib-exp-med-0-value").rules( "add", {
         betweenMinMaxCompNA: $("input[name*='field_proc_req_viib']").filter("input[name*='field_exp_med']"),
         messages: {
           betweenMinMaxCompNA: "This field should be between the largest and smallest values of Median Number of Days"
-        }
-      });
-
-      // VII.B. Expedited Processing - Agency Overall Lowest Number of Days
-      $( "#edit-field-overall-viib-exp-low-0-value").rules( "add", {
-        equalToLowestComp: $("input[name*='field_proc_req_viib']").filter("input[name*='field_exp_low']"),
-        messages: {
-          equalToLowestComp: "Must equal smallest value of Lowest number of days."
         }
       });
 
@@ -980,14 +940,6 @@
         $('input[name="' + comparison_input + '"]').once('VIIBExpHighValidate').keyup(function(event) {
           revalidateOnKeyup(event, that);
         })
-      });
-
-      // VII.B. Expedited Processing - Agency Overall Highest Number of Days
-      $( "#edit-field-overall-viib-exp-high-0-value").rules( "add", {
-        equalToHighestComp: $("input[name*='field_proc_req_viib']").filter("input[name*='field_exp_high']"),
-        messages: {
-          equalToHighestComp: "Must equal largest value of Highest number of days."
-        }
       });
 
       // VII.D. Sum of requests in simple, complex, and expedited must be equal

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -762,24 +762,6 @@
         }
       });
 
-      // VI.C.(4) - Agency Overall Lowest Number of Days
-      $( "#edit-field-overall-vic4-low-num-days-0-value").rules( "add", {
-        lessThanEqualToNA: "#edit-field-overall-vic4-high-num-days-0-value",
-        greaterThanZeroOrNA: true,
-        messages: {
-          lessThanEqualToNA: "Must be lower than or equal to the highest number of days."
-        }
-      });
-
-      // VI.C.(4) - Agency Overall Highest Number of Days
-      $( "#edit-field-overall-vic4-high-num-days-0-value").rules( "add", {
-        greaterThanEqualToNA: "#edit-field-overall-vic4-low-num-days-0-value",
-        greaterThanZeroOrNA: true,
-        messages: {
-          greaterThanEqualToNA: "Must be greater than or equal to the lowest number of days."
-        }
-      });
-
       // VI.C.(5). TEN OLDEST PENDING ADMINISTRATIVE APPEALS / 2nd - 10th
       // Iterate over 2nd to 10th oldest overall pending appeals, comparing
       // the value to the one before it, e.g. value of 9th <= 8th.

--- a/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
+++ b/docroot/modules/custom/foia_ui/js/foia_ui.validation.js
@@ -817,35 +817,11 @@
         })
       });
 
-      // VII.A. Simple - Agency Overall Lowest Number of Days
-      $( "#edit-field-overall-viia-sim-low-0-value").rules( "add", {
-        equalToLowestComp: $("input[name*='field_proc_req_viia']").filter("input[name*='field_sim_low']"),
-        messages: {
-          equalToLowestComp: "Must equal smallest value of Lowest number of days."
-        }
-      });
-
-      // VII.A. Simple - Agency Overall Highest Number of Days
-      $( "#edit-field-overall-viia-sim-high-0-value").rules( "add", {
-        equalToHighestComp: $("input[name*='field_proc_req_viia']").filter("input[name*='field_sim_high']"),
-        messages: {
-          equalToHighestComp: "Must equal largest value of Highest number of days."
-        }
-      });
-
       // VII.A. Complex - Agency Overall Median Number of Days
       $( "#edit-field-overall-viia-comp-med-0-value").rules( "add", {
         betweenMinMaxCompNA: $("input[name*='field_proc_req_viia']").filter("input[name*='field_comp_med']"),
         messages: {
           betweenMinMaxCompNA: "This field should be between the largest and smallest values of Median Number of Days"
-        }
-      });
-
-      // VII.A. Complex - Agency Overall Lowest Number of Days
-      $( "#edit-field-overall-viia-comp-low-0-value").rules( "add", {
-        equalToLowestComp: $("input[name*='field_proc_req_viia']").filter("input[name*='field_comp_low']"),
-        messages: {
-          equalToLowestComp: "Must equal smallest value of Lowest number of days."
         }
       });
 
@@ -866,27 +842,11 @@
         })
       });
 
-      // VII.A. Complex - Agency Overall Highest Number of Days
-      $( "#edit-field-overall-viia-comp-high-0-value").rules( "add", {
-        equalToHighestComp: $("input[name*='field_proc_req_viia']").filter("input[name*='field_comp_high']"),
-        messages: {
-          equalToHighestComp: "Must equal largest value of Highest number of days."
-        }
-      });
-
       // VII.A. Expedited Processing - Agency Overall Median Number of Days
       $( "#edit-field-overall-viia-exp-med-0-value").rules( "add", {
         betweenMinMaxCompNA: $("input[name*='field_proc_req_viia']").filter("input[name*='field_exp_med']"),
         messages: {
           betweenMinMaxCompNA: "This field should be between the largest and smallest values of Median Number of Days"
-        }
-      });
-
-      // VII.A. Expedited Processing - Agency Overall Lowest Number of Days
-      $( "#edit-field-overall-viia-exp-low-0-value").rules( "add", {
-        equalToLowestComp: $("input[name*='field_proc_req_viia']").filter("input[name*='field_exp_low']"),
-        messages: {
-          equalToLowestComp: "Must equal smallest value of Lowest number of days."
         }
       });
 
@@ -905,14 +865,6 @@
         $('input[name="' + comparison_input + '"]').once('VIIAExpHighValidate').keyup(function(event) {
           revalidateOnKeyup(event, that);
         })
-      });
-
-      // VII.A. Expedited Processing - Agency Overall Highest Number of Days
-      $( "#edit-field-overall-viia-exp-high-0-value").rules( "add", {
-        equalToHighestComp: $("input[name*='field_proc_req_viia']").filter("input[name*='field_exp_high']"),
-        messages: {
-          equalToHighestComp: "Must equal largest value of Highest number of days."
-        }
       });
 
       // VII.B. Simple - Agency Overall Median Number of Days


### PR DESCRIPTION
I'm not absolutely sure that this validation should be removed, but the following fields are now auto-calculated and read-only, so it appears to be obsolete.

See https://acquiaps.atlassian.net/browse/FOIA-220
> Agency Overall high and low fields autocalc and do not have validation on them; however, they should be correct is all component high and low fields are correct. Verify this.

# VI.C.(4)

- Agency Overall Lowest Number of Days
- Agency Overall Highest Number of Days

# VII.A.

- Simple - Agency Overall Lowest Number of Days
- Simple - Agency Overall Highest Number of Days
- Complex - Agency Overall Lowest Number of Days
- Complex - Agency Overall Highest Number of Days
- Expedited Processing - Agency Overall Lowest Number of Days
- Expedited Processing - Agency Overall Highest Number of Days

# VII.B.

- Simple - Agency Overall Lowest Number of Days
- Simple - Agency Overall Highest Number of Days
- Complex - Agency Overall Lowest Number of Days
- Complex - Agency Overall Highest Number of Days
- Expedited Processing - Agency Overall Lowest Number of Days
- Expedited Processing - Agency Overall Highest Number of Days
