### PR TITLE
FOIA-229: Set percentage field min/max of 0 & 1.

### DIFF
--- a/config/default/field.field.node.annual_foia_report_data.field_overall_x_perc_costs.yml
+++ b/config/default/field.field.node.annual_foia_report_data.field_overall_x_perc_costs.yml
@@ -23,8 +23,8 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: null
-  max: null
+  min: !!float 0
+  max: !!float 1
   prefix: ''
   suffix: ''
 field_type: decimal

--- a/config/default/field.field.paragraph.fees_x.field_perc_costs.yml
+++ b/config/default/field.field.paragraph.fees_x.field_perc_costs.yml
@@ -23,8 +23,8 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: null
-  max: null
+  min: !!float 0
+  max: !!float 1
   prefix: ''
   suffix: ''
 field_type: decimal


### PR DESCRIPTION
* Sets a minimum value of 0 for paragraph and agency overall percentage fields in section X.
* Sets a maximum value of 1 for paragraph and agency overall percentage fields in section X.

Notes: 
* Setting the percentage fields min and max values to 0 and 1, respectively does not change the ability to import those values.  Importing xml files with values in those fields that are greater than 1 still imports the node and the field value.  I would assume that this is correct b/c we would value importing data so it can be changed later over attempting to correct invalid data.  If that is not the case, we need to do more work to manage these values within the import process.
* The min/max values do mean that saving a node with values greater than 1 (or less than 0) would cause Drupal errors and the node won’t save.  Based on the request, this sounds like the expected outcome. 