### PR TITLE
FOIA-32: Batch publish Annual Report.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,8 @@
                 "JSONAPI fix for missing entities": "https://www.drupal.org/files/issues/2019-06-21/drupal--jsonapi--3063326--public-name-for-relatable-fields.patch",
                 "FOIA-96: Style read-only inputs as disabled": "./patches/FOIA-96-readonly-inputs.patch",
                 "FOIA-227: large numbers w/decimals fail validation": "https://www.drupal.org/files/issues/2019-05-04/drupal_2230909_138.patch",
-                "FOIA-32: Dynamically provide action plugins for every moderation state change": "https://www.drupal.org/files/issues/2019-11-20/2797583_provide_moderation_states_as_actions_128.patch"
+                "FOIA-32: Dynamically provide action plugins for every moderation state change": "https://www.drupal.org/files/issues/2019-11-20/2797583_provide_moderation_states_as_actions_128.patch",
+                "FOIA-32: Exclude Agency/Component from validation for bulk publishing": "./patches/FOIA-32-validator.patch"
             },
             "drupal/password_policy": {
                 "Config install issues": "https://www.drupal.org/files/issues/password-policy-config-import-field-error-2771129-49-D8.patch",

--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,8 @@
                 "Account for null triggering element when validating managed file elements": "https://www.drupal.org/files/issues/validating_managed-2910320-2.patch",
                 "JSONAPI fix for missing entities": "https://www.drupal.org/files/issues/2019-06-21/drupal--jsonapi--3063326--public-name-for-relatable-fields.patch",
                 "FOIA-96: Style read-only inputs as disabled": "./patches/FOIA-96-readonly-inputs.patch",
-                "FOIA-227: large numbers w/decimals fail validation": "https://www.drupal.org/files/issues/2019-05-04/drupal_2230909_138.patch"
+                "FOIA-227: large numbers w/decimals fail validation": "https://www.drupal.org/files/issues/2019-05-04/drupal_2230909_138.patch",
+                "FOIA-32: Dynamically provide action plugins for every moderation state change": "https://www.drupal.org/files/issues/2019-11-18/2797583-126_8_7_x_0.patch"
             },
             "drupal/password_policy": {
                 "Config install issues": "https://www.drupal.org/files/issues/password-policy-config-import-field-error-2771129-49-D8.patch",

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
                 "JSONAPI fix for missing entities": "https://www.drupal.org/files/issues/2019-06-21/drupal--jsonapi--3063326--public-name-for-relatable-fields.patch",
                 "FOIA-96: Style read-only inputs as disabled": "./patches/FOIA-96-readonly-inputs.patch",
                 "FOIA-227: large numbers w/decimals fail validation": "https://www.drupal.org/files/issues/2019-05-04/drupal_2230909_138.patch",
-                "FOIA-32: Dynamically provide action plugins for every moderation state change": "https://www.drupal.org/files/issues/2019-11-18/2797583-126_8_7_x_0.patch"
+                "FOIA-32: Dynamically provide action plugins for every moderation state change": "https://www.drupal.org/files/issues/2019-11-20/2797583_provide_moderation_states_as_actions_128.patch"
             },
             "drupal/password_policy": {
                 "Config install issues": "https://www.drupal.org/files/issues/password-policy-config-import-field-error-2771129-49-D8.patch",

--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,7 @@
                 "FOIA-96: Style read-only inputs as disabled": "./patches/FOIA-96-readonly-inputs.patch",
                 "FOIA-227: large numbers w/decimals fail validation": "https://www.drupal.org/files/issues/2019-05-04/drupal_2230909_138.patch",
                 "FOIA-32: Dynamically provide action plugins for every moderation state change": "https://www.drupal.org/files/issues/2019-11-20/2797583_provide_moderation_states_as_actions_128.patch",
+                "FOIA-32: Allow null value for ViewsSelection validateReferenceableEntities": "https://www.drupal.org/files/issues/2909132-3.patch",
                 "FOIA-32: Exclude Agency/Component from validation for bulk publishing": "./patches/FOIA-32-validator.patch"
             },
             "drupal/password_policy": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7b5b9d4e3067031c5fa3331113b73ba",
+    "content-hash": "724dd8dd5eb4c00dbbba1a346083a8b2",
     "packages": [
         {
             "name": "acquia/blt",
@@ -874,7 +874,7 @@
             "version": "3.4.1",
             "source": {
                 "type": "git",
-                "url": "git@github.com:jquery/jquery-dist.git",
+                "url": "https://github.com/jquery/jquery-dist.git",
                 "reference": "15bc73803f76bc53b654b9fdbbbc096f56d7c03d"
             },
             "dist": {
@@ -892,7 +892,7 @@
             "version": "v1.8.1",
             "source": {
                 "type": "git",
-                "url": "git@github.com:kenwheeler/slick.git",
+                "url": "https://github.com/kenwheeler/slick.git",
                 "reference": "0f40c9d6a02a5c08b5f4dd80fdada3a854a59bee"
             },
             "dist": {
@@ -2200,6 +2200,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
+            "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
         },
         {
@@ -4339,6 +4340,7 @@
                     "JSONAPI fix for missing entities": "https://www.drupal.org/files/issues/2019-06-21/drupal--jsonapi--3063326--public-name-for-relatable-fields.patch",
                     "FOIA-96: Style read-only inputs as disabled": "./patches/FOIA-96-readonly-inputs.patch",
                     "FOIA-227: large numbers w/decimals fail validation": "https://www.drupal.org/files/issues/2019-05-04/drupal_2230909_138.patch",
+                    "FOIA-32: Dynamically provide action plugins for every moderation state change": "https://www.drupal.org/files/issues/2019-11-18/2797583-126_8_7_x_0.patch",
                     "2869592 - Disabled update module shouldn't produce a status report warning": "https://www.drupal.org/files/issues/2869592-remove-update-warning-7.patch",
                     "2885441 - EntityReferenceAutocompleteWidget should define its size setting as an integer": "https://www.drupal.org/files/issues/2885441-2.patch",
                     "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2019-03-05/2815221-116.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3883cf065d77ce5ac16a9317e51947dc",
+    "content-hash": "51a3d5a91bc176bbc77872a700ad227b",
     "packages": [
         {
             "name": "acquia/blt",
@@ -892,7 +892,7 @@
             "version": "v1.8.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/kenwheeler/slick.git",
+                "url": "git@github.com:kenwheeler/slick.git",
                 "reference": "0f40c9d6a02a5c08b5f4dd80fdada3a854a59bee"
             },
             "dist": {
@@ -4341,6 +4341,7 @@
                     "FOIA-96: Style read-only inputs as disabled": "./patches/FOIA-96-readonly-inputs.patch",
                     "FOIA-227: large numbers w/decimals fail validation": "https://www.drupal.org/files/issues/2019-05-04/drupal_2230909_138.patch",
                     "FOIA-32: Dynamically provide action plugins for every moderation state change": "https://www.drupal.org/files/issues/2019-11-20/2797583_provide_moderation_states_as_actions_128.patch",
+                    "FOIA-32: Exclude Agency/Component from validation for bulk publishing": "./patches/FOIA-32-validator.patch",
                     "2869592 - Disabled update module shouldn't produce a status report warning": "https://www.drupal.org/files/issues/2869592-remove-update-warning-7.patch",
                     "2885441 - EntityReferenceAutocompleteWidget should define its size setting as an integer": "https://www.drupal.org/files/issues/2885441-2.patch",
                     "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2019-03-05/2815221-116.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "724dd8dd5eb4c00dbbba1a346083a8b2",
+    "content-hash": "3883cf065d77ce5ac16a9317e51947dc",
     "packages": [
         {
             "name": "acquia/blt",
@@ -4340,7 +4340,7 @@
                     "JSONAPI fix for missing entities": "https://www.drupal.org/files/issues/2019-06-21/drupal--jsonapi--3063326--public-name-for-relatable-fields.patch",
                     "FOIA-96: Style read-only inputs as disabled": "./patches/FOIA-96-readonly-inputs.patch",
                     "FOIA-227: large numbers w/decimals fail validation": "https://www.drupal.org/files/issues/2019-05-04/drupal_2230909_138.patch",
-                    "FOIA-32: Dynamically provide action plugins for every moderation state change": "https://www.drupal.org/files/issues/2019-11-18/2797583-126_8_7_x_0.patch",
+                    "FOIA-32: Dynamically provide action plugins for every moderation state change": "https://www.drupal.org/files/issues/2019-11-20/2797583_provide_moderation_states_as_actions_128.patch",
                     "2869592 - Disabled update module shouldn't produce a status report warning": "https://www.drupal.org/files/issues/2869592-remove-update-warning-7.patch",
                     "2885441 - EntityReferenceAutocompleteWidget should define its size setting as an integer": "https://www.drupal.org/files/issues/2885441-2.patch",
                     "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2019-03-05/2815221-116.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51a3d5a91bc176bbc77872a700ad227b",
+    "content-hash": "9a7573eac8f2c7cd9f4be0c926e34ff3",
     "packages": [
         {
             "name": "acquia/blt",
@@ -4341,6 +4341,7 @@
                     "FOIA-96: Style read-only inputs as disabled": "./patches/FOIA-96-readonly-inputs.patch",
                     "FOIA-227: large numbers w/decimals fail validation": "https://www.drupal.org/files/issues/2019-05-04/drupal_2230909_138.patch",
                     "FOIA-32: Dynamically provide action plugins for every moderation state change": "https://www.drupal.org/files/issues/2019-11-20/2797583_provide_moderation_states_as_actions_128.patch",
+                    "FOIA-32: Allow null value for ViewsSelection validateReferenceableEntities": "https://www.drupal.org/files/issues/2909132-3.patch",
                     "FOIA-32: Exclude Agency/Component from validation for bulk publishing": "./patches/FOIA-32-validator.patch",
                     "2869592 - Disabled update module shouldn't produce a status report warning": "https://www.drupal.org/files/issues/2869592-remove-update-warning-7.patch",
                     "2885441 - EntityReferenceAutocompleteWidget should define its size setting as an integer": "https://www.drupal.org/files/issues/2885441-2.patch",

--- a/config/default/action.settings.yml
+++ b/config/default/action.settings.yml
@@ -1,0 +1,3 @@
+recursion_limit: 35
+_core:
+  default_config_hash: X4YpfA5OdcR0yUAF6UsJxqmOdrviYYj45h_SAH_p4oU

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -1,4 +1,5 @@
 module:
+  action: 0
   address: 0
   auto_entitylabel: 0
   autologout: 0

--- a/config/default/lightning_core.versions.yml
+++ b/config/default/lightning_core.versions.yml
@@ -1,3 +1,4 @@
+action: 8.7.5
 address: 1.2.0
 autologout: 1.0.0
 autosave_form: 1.0.0

--- a/config/default/system.action.change_moderation_state_of_content.yml
+++ b/config/default/system.action.change_moderation_state_of_content.yml
@@ -1,0 +1,16 @@
+uuid: 99a180f4-5856-4495-aa8a-02cc924f2225
+langcode: en
+status: true
+dependencies:
+  config:
+    - workflows.workflow.annual_report_workflow
+  module:
+    - content_moderation
+    - node
+id: change_moderation_state_of_content
+label: Publish
+type: node
+plugin: 'moderation_state_change:node'
+configuration:
+  workflow: annual_report_workflow
+  state: published

--- a/patches/FOIA-32-validator.patch
+++ b/patches/FOIA-32-validator.patch
@@ -1,0 +1,16 @@
+diff --git a/core/lib/Drupal/Core/Entity/Plugin/Validation/Constraint/ValidReferenceConstraintValidator.php b/core/lib/Drupal/Core/Entity/Plugin/Validation/Constraint/ValidReferenceConstraintValidator.php
+index aef9fb0018..2f6998d948 100644
+--- a/core/lib/Drupal/Core/Entity/Plugin/Validation/Constraint/ValidReferenceConstraintValidator.php
++++ b/core/lib/Drupal/Core/Entity/Plugin/Validation/Constraint/ValidReferenceConstraintValidator.php
+@@ -143,6 +143,11 @@ class ValidReferenceConstraintValidator extends ConstraintValidator implements C
+             continue;
+           }
+
++          // Exclude agency/component validation for bulk publishing.
++          if(\Drupal::routeMatch()->getRouteName() == 'system.admin_content' && $handler->getConfiguration()['view']['view_name'] == "agency_component_by_agency") {
++            continue;
++          }
++
+           $message = isset($existing_entities[$target_id]) ? $constraint->message : $constraint->nonExistingMessage;
+           $this->context->buildViolation($message)
+             ->setParameter('%type', $target_type_id)


### PR DESCRIPTION
# Work in Progress, do not merge

- Applies core patch to add bulk actions for content moderation changes
- Adds and enables _Publish_ bulk content moderation action
- Applies core patch to not generate error message on empty Agency/Component entity reference validation.
- Includes and applies custom core patch to exclude Agency/Component entity reference from validation errors (due to contextual filter argument from content URL).