### PR TITLE
FOIA-230: Use human readable state in admin view.

### DIFF
--- a/config/default/views.view.content.yml
+++ b/config/default/views.view.content.yml
@@ -82,6 +82,7 @@ display:
             field_foia_annual_report_yr: field_foia_annual_report_yr
             changed: changed
             operations: operations
+            moderation_state_1: moderation_state_1
             moderation_state: moderation_state
           info:
             node_bulk_form:
@@ -125,6 +126,13 @@ display:
               empty_column: false
               responsive: priority-low
             operations:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            moderation_state_1:
+              sortable: true
+              default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
@@ -845,6 +853,69 @@ display:
           hide_alter_empty: true
           destination: true
           plugin_id: entity_operations
+        moderation_state_1:
+          id: moderation_state_1
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: content_moderation_state
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          plugin_id: field
         moderation_state:
           id: moderation_state
           table: content_moderation_state_field_data
@@ -855,8 +926,8 @@ display:
           label: Status
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '{{ moderation_state_1 }}'
             make_link: false
             path: ''
             absolute: false


### PR DESCRIPTION
* Adds the human readable moderation state as a hidden field in the admin/content view
* Displays the human readable moderation state in the Status column of the admin/content view

The method of using a hidden field and rewriting the Status column with the value in the hidden field  is being used because sorting the status column was failing when only using the human readable field value.  I believe this is because using only the human readable field did not use the content moderation state relationship, so couldn't get values for the field on nodes that were not Annual Report Data nodes.