### PR TITLE
FOIA-312: Allow viewing unpublished agency components.

### DIFF
--- a/config/default/jsonapi_extras.jsonapi_resource_config.node--agency_component.yml
+++ b/config/default/jsonapi_extras.jsonapi_resource_config.node--agency_component.yml
@@ -58,11 +58,11 @@ resourceFields:
     enhancer:
       id: ''
   status:
-    disabled: true
     fieldName: status
     publicName: status
     enhancer:
       id: ''
+    disabled: false
   uid:
     disabled: true
     fieldName: uid
@@ -117,6 +117,12 @@ resourceFields:
     publicName: revision_translation_affected
     enhancer:
       id: ''
+  moderation_state:
+    fieldName: moderation_state
+    publicName: moderation_state
+    enhancer:
+      id: ''
+    disabled: false
   scheduled_transition_date:
     disabled: true
     fieldName: scheduled_transition_date
@@ -276,6 +282,18 @@ resourceFields:
   field_receiver:
     fieldName: field_receiver
     publicName: paper_receiver
+    enhancer:
+      id: ''
+    disabled: false
+  field_rep_exp:
+    fieldName: field_rep_exp
+    publicName: field_rep_exp
+    enhancer:
+      id: ''
+    disabled: false
+  field_rep_start:
+    fieldName: field_rep_start
+    publicName: field_rep_start
     enhancer:
       id: ''
     disabled: false

--- a/config/default/user.role.anonymous.yml
+++ b/config/default/user.role.anonymous.yml
@@ -13,6 +13,7 @@ permissions:
   - 'access content'
   - 'access site-wide contact form'
   - 'restful post webform_submission'
+  - 'view any unpublished agency_component content'
   - 'view field_complex_average_days'
   - 'view field_complex_highest_days'
   - 'view field_complex_lowest_days'

--- a/config/default/user.role.anonymous.yml
+++ b/config/default/user.role.anonymous.yml
@@ -23,6 +23,7 @@ permissions:
   - 'view field_expedited_lowest_days'
   - 'view field_expedited_median_days'
   - 'view field_is_centralized'
+  - 'view field_rep_start'
   - 'view field_request_data_year'
   - 'view field_request_submission_form'
   - 'view field_simple_average_days'

--- a/docroot/modules/custom/foia_api/foia_api.module
+++ b/docroot/modules/custom/foia_api/foia_api.module
@@ -1,0 +1,27 @@
+<?php
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Access\AccessResultAllowed;
+
+/**
+ * Implements hook_jsonapi_ENTITY_TYPE_filter_access().
+ */
+function foia_api_jsonapi_node_filter_access(EntityTypeInterface $entity_type, AccountInterface $account) {
+  $access = $account->hasPermission('view any unpublished agency_component content')
+    || $account->hasPermission('view any unpublished content')
+    || $account->hasPermission('view any unpublished annual_foia_report_data content');
+
+  // At this point we are unable to restrict access by node type, so as long
+  // as the account has access to view unpublished nodes of either the
+  // annual_foia_report_data or agency_component type, we will allow jsonapi
+  // access to filter among all nodes.  This fixes an issue where jsonapi was
+  // adding a status=1 condition to queries for agency_components when the
+  // request included a filter parameter. Access can still be restricted with a
+  // default status filter, such as for the /api/annual_foia_report endpoint.
+  if ($access) {
+    return [
+      JSONAPI_FILTER_AMONG_ALL => AccessResultAllowed::allowed(),
+    ];
+  }
+}


### PR DESCRIPTION
* Gives users access to view any unpublished agency component
in order to satisfy the requirement that unpublished
agency_component nodes are accessible via the api.
* Includes the status field in the agency_component endpoint
in order to allow filtering by status in the request.
* Gives users access to view any field_rep_start value in order
to allow filtering by field_rep_start values in an agency component
request.
* Gives access to jsonapi to filter from all nodes in order to allow
access to unpublished agency components via the api.