### PR TITLE
FOIA-359: Cast string fields when numeric.

### DIFF
--- a/docroot/modules/custom/foia_api/foia_api.module
+++ b/docroot/modules/custom/foia_api/foia_api.module
@@ -65,12 +65,16 @@ function foia_api_query_alter(AlterableInterface $query) {
  */
 function _foia_api_cast_condition_values($parent, $query) {
   foreach($parent->conditions() as $delta => &$condition) {
+    if (!is_array($condition)) {
+      continue;
+    }
+
     if ($condition['field'] instanceof ConditionInterface) {
       _foia_api_cast_condition_values($condition['field'], $query);
       continue;
     }
 
-    if (is_array($condition) && _foia_api_is_string_field($condition['field']) && is_numeric($condition['value'])) {
+    if (_foia_api_is_string_field($condition['field']) && is_numeric($condition['value'])) {
       // Current condition values.
       $value = (int) $condition['value'];
       $operator = $condition['operator'];

--- a/docroot/modules/custom/foia_api/foia_api.module
+++ b/docroot/modules/custom/foia_api/foia_api.module
@@ -3,6 +3,9 @@
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Access\AccessResultAllowed;
+use Drupal\Core\Database\Query\AlterableInterface;
+use Drupal\Core\Database\Query\ConditionInterface;
+use Drupal\Core\Database\Query\QueryConditionTrait;
 
 /**
  * Implements hook_jsonapi_ENTITY_TYPE_filter_access().
@@ -33,4 +36,132 @@ function foia_api_jsonapi_paragraph_filter_access(EntityTypeInterface $entity_ty
   return [
     JSONAPI_FILTER_AMONG_PUBLISHED => AccessResultAllowed::allowed(),
   ];
+}
+
+/**
+ * Implements hook_query_alter().
+ */
+function foia_api_query_alter(AlterableInterface $query) {
+  // Only alter annual_foia_report api requests.
+  $path = \Drupal::request()->getPathInfo();
+  if ($path !== '/api/annual_foia_report' && !$query->hasTag('entity_query_node')) {
+    return;
+  }
+  // There are some fields that store numeric values, but are stored as strings
+  // so that special values such as 'N/A' and '<1' can be used.  If a condition
+  // is attempting to compare a numeric value to one of these string values,
+  // check that the value in the database is numeric and cast it to an integer
+  // before comparing it in the query condition.
+  _foia_api_cast_condition_values($query, $query);
+}
+
+/**
+ * Alter query conditions that compare numeric values to string fields.
+ *
+ * @param ConditionInterface|QueryConditionTrait $parent
+ *   A query or condition group that has conditions which may be alterable.
+ * @param AlterableInterface $query
+ *   The query being altered, used to build the placeholder id.
+ */
+function _foia_api_cast_condition_values($parent, $query) {
+  foreach($parent->conditions() as $delta => &$condition) {
+    if ($condition['field'] instanceof ConditionInterface) {
+      _foia_api_cast_condition_values($condition['field'], $query);
+      continue;
+    }
+
+    if (is_array($condition) && _foia_api_is_string_field($condition['field']) && is_numeric($condition['value'])) {
+      // Current condition values.
+      $value = (int) $condition['value'];
+      $operator = $condition['operator'];
+      $placeholder = ":db_condition_placeholder_{$query->nextPlaceholder()}";
+
+      // Build an expression that checks if the field is numeric and casts
+      // the field to an unsigned integer if it is.
+      $is_numeric_expression = "{$condition['field']} REGEXP '^[0-9]+$'";
+      $if_numeric_expression = "CAST({$condition['field']} as UNSIGNED) $operator $placeholder";
+      $if_not_numeric_expression = "{$condition['field']} $operator $placeholder";
+
+      // Set the new condition values.
+      $condition['field'] = "IF($is_numeric_expression, $if_numeric_expression, $if_not_numeric_expression)" ;
+      $condition['value'] = [$placeholder => $value];
+      unset($condition['operator']);
+    }
+  }
+}
+
+/**
+ * Checks if a field from a database condition is a string field.
+ *
+ * @param string $database_field
+ *   A field from a database condition, such as
+ *   `paragraph__field_sim_med.field_sim_med_value`.
+ *
+ * @return bool
+ */
+function _foia_api_is_string_field($database_field) {
+  $string_fields = _foia_api_get_string_fields('node', 'annual_foia_report_data');
+  $matches = array_filter($string_fields, function($field) use ($database_field) {
+    if (strpos($database_field, $field->getTargetEntityTypeId()) !== 0) {
+      return false;
+    }
+
+    return strstr($database_field, $field->getName()) !== FALSE;
+  });
+
+  return !empty($matches);
+}
+
+/**
+ * Builds a list of string fields from an entity type, including references.
+ *
+ * @param string $entity_type
+ *   The entity type to start the list of fields from.
+ * @param string $bundle
+ *   The entity bundle type to start the list of fields from.
+ *
+ * @return array|mixed
+ *   An array of all fields on the requested bundle, and any referenced bundles,
+ *   with the type 'string'.
+ */
+function _foia_api_get_string_fields($entity_type, $bundle) {
+  $string_fields = &drupal_static(__FUNCTION__ . '_' . $entity_type . '_' . $bundle, []);
+  if (!empty($string_fields)) {
+    return $string_fields;
+  }
+
+  $bundle_fields = \Drupal::getContainer()
+    ->get('entity_field.manager')
+    ->getFieldDefinitions($entity_type, $bundle);
+
+  // Builds the base list of string fields attached to this bundle.
+  $string_fields = array_filter($bundle_fields, function($field) {
+    return $field->getType() === 'string';
+  });
+
+  // Add string fields from entity types that are referenced by this
+  // bundle.
+  $entity_reference_fields = array_filter($bundle_fields, function($field) {
+    return $field->getType() === 'entity_reference_revisions';
+  });
+  $string_fields = array_reduce($entity_reference_fields, function($string_fields, $field) {
+    $settings = $field->getSettings();
+    $bundles = $settings['handler_settings']['target_bundles'] ?? [];
+    $type = $settings['target_type'];
+
+    $new_string_fields = array_reduce($bundles, function($child_string_fields, $bundle) use ($type) {
+      $child_string_fields += _foia_api_get_string_fields($type, $bundle);
+
+      return $child_string_fields;
+    }, []);
+    return $string_fields + $new_string_fields;
+  }, $string_fields);
+
+  // Remove system fields.
+  $system_keys = array_filter(array_keys($string_fields), function($field_name) {
+    return strpos($field_name, 'field_') === FALSE;
+  });
+  $string_fields = array_diff_key($string_fields, array_flip($system_keys));
+
+  return $string_fields;
 }


### PR DESCRIPTION
Some numeric values are stored in the database as string fields so that
the special values 'N/A' and '<1' can be used in those fields.  In order
to properly compare values during api requests, check if the value in
the database is numeric and cast it to an integer if it is being
compared to a numeric value.