### PR TITLE
FOIA-368: Bulk report xml uploader.

### DIFF
--- a/docroot/modules/custom/foia_upload_xml/composer.json
+++ b/docroot/modules/custom/foia_upload_xml/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "foia_upload_xml",
+    "description": "Provides a drush bulk upload command for FOIA agency reports.",
+    "type": "drupal-drush",
+    "require": {
+        "php": ">=5.6.0"
+    },
+    "extra": {
+        "drush": {
+            "services": {
+                "drush.services.yml": "^9"
+            }
+        }
+    }
+}

--- a/docroot/modules/custom/foia_upload_xml/drush.services.yml
+++ b/docroot/modules/custom/foia_upload_xml/drush.services.yml
@@ -1,6 +1,6 @@
 services:
   foia_upload_xml.commands:
     class: \Drupal\foia_upload_xml\Commands\FoiaUploadXmlCommands
-    arguments: ['@database', '@logger.factory', '@messenger', '@foia_upload_xml.migrations_processor', '@foia_upload_xml.report_parser']
+    arguments: ['@database', '@entity_type.manager', '@logger.factory', '@foia_upload_xml.migrations_processor', '@foia_upload_xml.report_parser']
     tags:
       - { name: drush.command }

--- a/docroot/modules/custom/foia_upload_xml/drush.services.yml
+++ b/docroot/modules/custom/foia_upload_xml/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  foia_upload_xml.commands:
+    class: \Drupal\foia_upload_xml\Commands\FoiaUploadXmlCommands
+    arguments: ['@messenger', '@foia_upload_xml.migrations_processor', '@foia_upload_xml.report_parser']
+    tags:
+      - { name: drush.command }

--- a/docroot/modules/custom/foia_upload_xml/drush.services.yml
+++ b/docroot/modules/custom/foia_upload_xml/drush.services.yml
@@ -1,6 +1,6 @@
 services:
   foia_upload_xml.commands:
     class: \Drupal\foia_upload_xml\Commands\FoiaUploadXmlCommands
-    arguments: ['@messenger', '@foia_upload_xml.migrations_processor', '@foia_upload_xml.report_parser']
+    arguments: ['@database', '@logger.factory', '@messenger', '@foia_upload_xml.migrations_processor', '@foia_upload_xml.report_parser']
     tags:
       - { name: drush.command }

--- a/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Drupal\foia_upload_xml\Commands;
+
+use Drush\Utils\FsUtils;
+use Drupal\file\Entity\File;
+use Drupal\user\Entity\User;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\migrate\Plugin\MigrateIdMapInterface;
+use Drupal\foia_upload_xml\FoiaUploadXmlReportParser;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\foia_upload_xml\FoiaUploadXmlMigrationsProcessor;
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Drush\Commands\DrushCommands;
+
+/**
+ * A Drush commandfile for the FoiaUploadXmlCommands.
+ *
+ *
+ * See these files for an example of injecting Drupal services:
+ *   - http://cgit.drupalcode.org/devel/tree/src/Commands/DevelCommands.php
+ *   - http://cgit.drupalcode.org/devel/tree/drush.services.yml
+ */
+class FoiaUploadXmlCommands extends DrushCommands {
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The report parser.
+   *
+   * @var \Drupal\foia_upload_xml\FoiaUploadXmlReportParser
+   */
+  protected $reportParser;
+
+  /**
+   * The migrations processor.
+   *
+   * @var \Drupal\foia_upload_xml\FoiaUploadXmlMigrationsProcessor
+   */
+  protected $migrationsProcessor;
+
+  public function __construct(MessengerInterface $messenger, FoiaUploadXmlMigrationsProcessor $migrationsProcessor, FoiaUploadXmlReportParser $reportParser) {
+    parent::__construct();
+    $this->messenger = $messenger;
+    $this->migrationsProcessor = $migrationsProcessor;
+    $this->reportParser = $reportParser;
+  }
+
+
+  /**
+   * Command description here.
+   *
+   * @param $directory
+   *   Argument description.
+   *
+   * @usage foia_upload_xml:bulkProcess /path/to/files/directory
+   *   Usage description
+   *
+   * @command foia_upload_xml:bulkProcess
+   * @aliases fuxb
+   * @bootstrap full
+   */
+  public function bulkProcess($directory) {
+    $rows = [];
+    $realpath = FsUtils::realpath($directory);
+    $files = glob("$realpath/*.xml");
+    foreach ($files as $filepath) {
+      $info = pathinfo($filepath);
+      if (!is_file($filepath)) {
+        continue;
+      }
+
+      if (!is_readable($filepath)) {
+        $this->messenger->addWarning(t('Skipped @file: File not readable.', [
+          '@file' => $info['basename'],
+        ]));
+
+        $rows[] = [
+          'file' => $info['basename'],
+          'status' => 'Skipped, file not readable',
+        ];
+        continue;
+      }
+
+      $source = File::create([
+        'uid' => 1,
+        'status' => 0, // temporary
+        'uri' => $filepath,
+      ]);
+
+      try {
+        $report_data = $this->reportParser->parse($source);
+        $agency = $report_data['agency'] ?? FALSE;
+        $year = $report_data['report_year'] ?? date('Y');
+
+        $this->migrationsProcessor->setSourceFile($source)
+          ->setUser(User::load(1))
+          ->processAll();
+
+        $status = \Drupal::database()
+          ->select('migrate_map_foia_agency_report', 'm')
+          ->fields('m', ['source_row_status'])
+          ->condition('sourceid1', $year)
+          ->condition('sourceid2', $agency)
+          ->execute()
+          ->fetchField();
+
+        if ((int) $status === MigrateIdMapInterface::STATUS_FAILED) {
+          throw new \Exception(\Drupal::translation()
+            ->translate('The file @file was unable to be imported.', [
+              '@file' => $filepath,
+            ]));
+        }
+
+        $rows[] = [
+          'file' => $info['basename'],
+          'status' => 'Processed',
+        ];
+      } catch (\Exception $e) {
+        \Drupal::logger('foia_upload_xml')
+          ->warning(t('Foia Upload XML Bulk Upload: Failed to import @file.', [
+            '@file' => $info['basename'],
+          ]));
+        $rows[] = [
+          'file' => $info['basename'],
+          'status' => 'Failed',
+        ];
+      }
+    }
+
+    return new RowsOfFields($rows);
+  }
+}

--- a/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
@@ -57,7 +57,8 @@ class FoiaUploadXmlCommands extends DrushCommands {
    *
    * @param $directory
    *   The path to the directory containing the report xml files.  This can
-   *   be an absolute path or a relative path from the site's docroot.
+   *   be an absolute path on the server or a relative path from the site's
+   *   docroot.
    *
    * @usage foia_upload_xml:bulkProcess sites/default/files/report-files
    *   Bulk import all report *.xml files that are in the directory

--- a/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
@@ -115,7 +115,9 @@ class FoiaUploadXmlCommands extends DrushCommands {
 
       if (!is_readable($filepath)) {
         $this->loggerFactory->get('foia_upload_xml')
-          ->warning(dt("Skipped {$info['basename']}: File not readable."));
+          ->warning(dt("Skipped @file: File not readable.", [
+            '@file' => $info['basename'],
+          ]));
 
         $rows[] = [
           'file' => $info['basename'],
@@ -140,7 +142,9 @@ class FoiaUploadXmlCommands extends DrushCommands {
 
         $status = $this->migrationStatus($source);
         if ($status === MigrateIdMapInterface::STATUS_FAILED) {
-          throw new \Exception(dt("The file $filepath was unable to be imported."));
+          throw new \Exception(dt("The file @file was unable to be imported.", [
+            '@file' => $filepath,
+          ]));
         }
 
         $rows[] = [
@@ -150,7 +154,9 @@ class FoiaUploadXmlCommands extends DrushCommands {
       }
       catch (\Exception $e) {
         $this->loggerFactory->get('foia_upload_xml')
-          ->warning(dt("Foia Upload XML Bulk Upload: Failed to import {$info['basename']}."));
+          ->warning(dt("Foia Upload XML Bulk Upload: Failed to import @file.", [
+            '@file' => $info['basename'],
+          ]));
         $rows[] = [
           'file' => $info['basename'],
           'status' => 'Failed',

--- a/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\foia_upload_xml\Commands;
 
-use Drush\Utils\FsUtils;
 use Drupal\file\Entity\File;
 use Drupal\user\Entity\User;
 use Drupal\file\FileInterface;
@@ -164,7 +163,7 @@ class FoiaUploadXmlCommands extends DrushCommands {
    *   are found, or false on error.
    */
   protected function getXmlFiles($directory) {
-    $realpath = FsUtils::realpath($directory);
+    $realpath = realpath($directory) ?: $directory;
     return glob("$realpath/*.xml");
   }
 

--- a/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
@@ -53,20 +53,27 @@ class FoiaUploadXmlCommands extends DrushCommands {
 
 
   /**
-   * Command description here.
+   * Bulk import report xml files that are contained in a given directory.
    *
    * @param $directory
-   *   Argument description.
+   *   The path to the directory containing the report xml files.  This can
+   *   be an absolute path or a relative path from the site's docroot.
    *
-   * @usage foia_upload_xml:bulkProcess /path/to/files/directory
-   *   Usage description
+   * @usage foia_upload_xml:bulkProcess sites/default/files/report-files
+   *   Bulk import all report *.xml files that are in the directory
+   *   /path/to/docroot/sites/default/files/report-files.
    *
    * @command foia_upload_xml:bulkProcess
    * @aliases fuxb
    * @bootstrap full
    */
   public function bulkProcess($directory) {
-    $rows = [];
+    $rows = [
+      [
+        'file' => 'File',
+        'status' => 'Status'
+      ]
+    ];
     $files = $this->getXmlFiles($directory);
     foreach ($files as $filepath) {
       $info = pathinfo($filepath);

--- a/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
@@ -60,15 +60,15 @@ class FoiaUploadXmlCommands extends DrushCommands {
    *   be an absolute path on the server or a relative path from the site's
    *   docroot.
    *
-   * @usage foia_upload_xml:bulkProcess sites/default/files/report-files
+   * @usage foia-upload-xml:bulk-upload sites/default/files/report-files
    *   Bulk import all report *.xml files that are in the directory
    *   /path/to/docroot/sites/default/files/report-files.
    *
-   * @command foia_upload_xml:bulkProcess
-   * @aliases fuxb
+   * @command foia-upload-xml:bulk-upload
+   * @aliases fuxml
    * @bootstrap full
    */
-  public function bulkProcess($directory) {
+  public function bulkUpload($directory) {
     $rows = [
       [
         'file' => 'File',

--- a/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
@@ -87,6 +87,9 @@ class FoiaUploadXmlCommands extends DrushCommands {
         continue;
       }
 
+      // This file does not need to be saved or moved, as each file will be
+      // processed in place.  It is wrapped in a FileInterface class in order
+      // to be used by the migrations processor.
       $source = File::create([
         'uid' => 1,
         'status' => 0, // temporary

--- a/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
@@ -32,13 +32,6 @@ class FoiaUploadXmlCommands extends DrushCommands {
   protected $entityTypeManager;
 
   /**
-   * The logger channel factory.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
-   */
-  protected $loggerFactory;
-
-  /**
    * The migrations processor.
    *
    * @var \Drupal\foia_upload_xml\FoiaUploadXmlMigrationsProcessor
@@ -77,10 +70,10 @@ class FoiaUploadXmlCommands extends DrushCommands {
     parent::__construct();
     $this->connection = $database;
     $this->entityTypeManager = $entityTypeManager;
-    $this->loggerFactory = $loggerChannelFactory;
     $this->migrationsProcessor = $migrationsProcessor;
     $this->reportParser = $reportParser;
     $this->user = $this->entityTypeManager->getStorage('user')->load(1);
+    $this->setLogger($loggerChannelFactory->get('foia_upload_xml'));
   }
 
   /**
@@ -114,10 +107,9 @@ class FoiaUploadXmlCommands extends DrushCommands {
       }
 
       if (!is_readable($filepath)) {
-        $this->loggerFactory->get('foia_upload_xml')
-          ->warning(dt("Skipped @file: File not readable.", [
-            '@file' => $info['basename'],
-          ]));
+        $this->logger()->warning(dt("Skipped @file: File not readable.", [
+          '@file' => $info['basename'],
+        ]));
 
         $rows[] = [
           'file' => $info['basename'],
@@ -153,7 +145,7 @@ class FoiaUploadXmlCommands extends DrushCommands {
         ];
       }
       catch (\Exception $e) {
-        $this->loggerFactory->get('foia_upload_xml')
+        $this->logger()
           ->warning(dt("Foia Upload XML Bulk Upload: Failed to import @file.", [
             '@file' => $info['basename'],
           ]));

--- a/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
+++ b/docroot/modules/custom/foia_upload_xml/src/Commands/FoiaUploadXmlCommands.php
@@ -9,7 +9,6 @@ use Drupal\file\FileInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\migrate\Plugin\MigrateIdMapInterface;
 use Drupal\foia_upload_xml\FoiaUploadXmlReportParser;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\foia_upload_xml\FoiaUploadXmlMigrationsProcessor;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drush\Commands\DrushCommands;


### PR DESCRIPTION
* Adds a drush command to bulk import a directory of report xml files.
* `drush foia-upload-xml:bulk-upload path/to/report/files` OR `drush foia-upload-xml:bulk-upload /absolute/path/to/report/files`
* includes command alias `drush fuxml path/to/report/files`