### PR TITLE
FOIA-369: Create node on failure.

### DIFF
--- a/docroot/modules/custom/foia_upload_xml/foia_upload_xml.services.yml
+++ b/docroot/modules/custom/foia_upload_xml/foia_upload_xml.services.yml
@@ -17,6 +17,6 @@ services:
       - { name: 'event_subscriber' }
   foia_upload_xml.migration_post_import_subscriber:
     class: Drupal\foia_upload_xml\EventSubscriber\FoiaUploadXmlMigrationPostImportSubscriber
-    arguments: ['@messenger']
+    arguments: ['@messenger', '@entity_type.manager']
     tags:
       - { name: event_subscriber }

--- a/docroot/modules/custom/foia_upload_xml/foia_upload_xml.services.yml
+++ b/docroot/modules/custom/foia_upload_xml/foia_upload_xml.services.yml
@@ -15,3 +15,8 @@ services:
     class: Drupal\foia_upload_xml\EventSubscriber\FoiaUploadXmlMigrationSubscriber
     tags:
       - { name: 'event_subscriber' }
+  foia_upload_xml.migration_post_import_subscriber:
+    class: Drupal\foia_upload_xml\EventSubscriber\FoiaUploadXmlMigrationPostImportSubscriber
+    arguments: ['@messenger']
+    tags:
+      - { name: event_subscriber }

--- a/docroot/modules/custom/foia_upload_xml/src/EventSubscriber/FoiaUploadXmlMigrationPostImportSubscriber.php
+++ b/docroot/modules/custom/foia_upload_xml/src/EventSubscriber/FoiaUploadXmlMigrationPostImportSubscriber.php
@@ -90,13 +90,18 @@ class FoiaUploadXmlMigrationPostImportSubscriber implements EventSubscriberInter
       return;
     }
 
+    /** @var Row $row */
     $row = $migration->foiaErrorInformation['row'] ?? FALSE;
     if (!$row) {
       return;
     }
 
+    $saved = &drupal_static(__FUNCTION__ . md5(join('.', $row->getSourceIdValues())), FALSE);
+    if ($saved) {
+      return;
+    }
     $this->savePartial($migration, $row);
-    $this->getEventDispatcher()->removeListener(MigrateEvents::POST_IMPORT, [$this, 'onPostAgencyImport']);
+    $saved = TRUE;
   }
 
   /**

--- a/docroot/modules/custom/foia_upload_xml/src/EventSubscriber/FoiaUploadXmlMigrationPostImportSubscriber.php
+++ b/docroot/modules/custom/foia_upload_xml/src/EventSubscriber/FoiaUploadXmlMigrationPostImportSubscriber.php
@@ -51,26 +51,6 @@ class FoiaUploadXmlMigrationPostImportSubscriber implements EventSubscriberInter
   }
 
   /**
-   * Kernel request event handler.
-   *
-   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
-   *   Response event.
-   */
-  public function onKernelRequest(GetResponseEvent $event) {
-    $this->messenger->addStatus(__FUNCTION__);
-  }
-
-  /**
-   * Kernel response event handler.
-   *
-   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
-   *   Response event.
-   */
-  public function onKernelResponse(FilterResponseEvent $event) {
-    $this->messenger->addStatus(__FUNCTION__);
-  }
-
-  /**
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {

--- a/docroot/modules/custom/foia_upload_xml/src/EventSubscriber/FoiaUploadXmlMigrationPostImportSubscriber.php
+++ b/docroot/modules/custom/foia_upload_xml/src/EventSubscriber/FoiaUploadXmlMigrationPostImportSubscriber.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Drupal\foia_upload_xml\EventSubscriber;
+
+use Drupal\migrate\Row;
+use Drupal\Core\Utility\Error;
+use Drupal\migrate\MigrateMessage;
+use Drupal\migrate\MigrateException;
+use Drupal\migrate\Event\MigrateEvents;
+use Drupal\migrate\Event\MigrateImportEvent;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Plugin\MigrateIdMapInterface;
+use Drupal\migrate\Event\MigratePreRowSaveEvent;
+use Drupal\migrate\Event\MigratePostRowSaveEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * FOIA Upload XML event subscriber.
+ */
+class FoiaUploadXmlMigrationPostImportSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Constructs event subscriber.
+   *
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger.
+   */
+  public function __construct(MessengerInterface $messenger) {
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * Kernel request event handler.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+   *   Response event.
+   */
+  public function onKernelRequest(GetResponseEvent $event) {
+    $this->messenger->addStatus(__FUNCTION__);
+  }
+
+  /**
+   * Kernel response event handler.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+   *   Response event.
+   */
+  public function onKernelResponse(FilterResponseEvent $event) {
+    $this->messenger->addStatus(__FUNCTION__);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      MigrateEvents::POST_IMPORT => ['onPostAgencyImport'],
+    ];
+  }
+
+  /**
+   * Handle saving partial reports when report imports fail.
+   *
+   * @param \Drupal\migrate\Event\MigrateImportEvent $event
+   *   The migrate import event.
+   *
+   * @see \Drupal\foia_upload_xml\FoiaUploadXmlMigrateExecutable::processRow()
+   *   The foiaErrorInformation used to get and import the partially processed
+   *   row is set when the MigrateException is caught in the
+   *   FoiaUploadXmlMigrateExecutable::processRow() method.
+   */
+  public function onPostAgencyImport(MigrateImportEvent $event) {
+    $migration = $event->getMigration();
+    if (!$migration || $migration->id() !== 'foia_agency_report') {
+      return;
+    }
+
+    if (!property_exists($migration, 'foiaErrorInformation') || $migration->foiaErrorInformation['status'] !== MigrateIdMapInterface::STATUS_FAILED) {
+      return;
+    }
+
+    $row = $migration->foiaErrorInformation['row'] ?? FALSE;
+    if (!$row) {
+      return;
+    }
+
+    $this->savePartial($migration, $row);
+    $this->getEventDispatcher()->removeListener(MigrateEvents::POST_IMPORT, [$this, 'onPostAgencyImport']);
+  }
+
+  /**
+   * Save the partial agency report row, maintaining the failed import status.
+   *
+   * @param \Drupal\migrate\Plugin\MigrationInterface $migration
+   *   The failed migration.
+   * @param \Drupal\migrate\Row $row
+   *   The partially processed row, in the state it was in when the migration
+   *   failed.
+   *
+   * @see \Drupal\migrate\MigrateExecutable::import()
+   *   This implementation is based on the save process defined in the
+   *   MigrateExecutable::import() method.
+   */
+  public function savePartial(MigrationInterface $migration, Row $row) {
+    $id_map = $migration->getIdMap();
+    $destination = $migration->getDestinationPlugin();
+
+    try {
+      $this->getEventDispatcher()->dispatch(MigrateEvents::PRE_ROW_SAVE, new MigratePreRowSaveEvent($migration, new MigrateMessage(), $row));
+      $destination_ids = $id_map->lookupDestinationIds($row->getSourceIdValues());
+      $destination_id_values = $destination_ids ? reset($destination_ids) : [];
+      $destination_id_values = $destination->import($row, $destination_id_values);
+      $this->getEventDispatcher()->dispatch(MigrateEvents::POST_ROW_SAVE, new MigratePostRowSaveEvent($migration, new MigrateMessage(), $row, $destination_id_values));
+      $destination_id_values = $destination_id_values ?: [];
+      $rollback_action = !empty($destination_id_values) ? $destination->rollbackAction() : NULL;
+      // Save a mapping to the destination id values, while continuing to
+      // indicate that the row failed.
+      $id_map->saveIdMapping($row, $destination_id_values, MigrateIdMapInterface::STATUS_FAILED, $rollback_action);
+    }
+    catch (MigrateException $e) {
+      $id_map->saveIdMapping($row, [], $e->getStatus());
+      $id_map->saveMessage($row->getSourceIdValues(), $e->getMessage(), $e->getStatus());
+    }
+    catch (\Exception $e) {
+      $id_map->saveIdMapping($row, [], MigrateIdMapInterface::STATUS_FAILED);
+      $result = Error::decodeException($e);
+      $message = $result['@message'] . ' (' . $result['%file'] . ':' . $result['%line'] . ')';
+      (new MigrateMessage)->display($message, 'error');
+    }
+  }
+
+  /**
+   * Gets the event dispatcher.
+   *
+   * @return \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  private function getEventDispatcher() {
+    if (!$this->eventDispatcher) {
+      $this->eventDispatcher = \Drupal::service('event_dispatcher');
+    }
+    return $this->eventDispatcher;
+  }
+
+}

--- a/docroot/modules/custom/foia_upload_xml/src/EventSubscriber/FoiaUploadXmlMigrationPostImportSubscriber.php
+++ b/docroot/modules/custom/foia_upload_xml/src/EventSubscriber/FoiaUploadXmlMigrationPostImportSubscriber.php
@@ -86,6 +86,9 @@ class FoiaUploadXmlMigrationPostImportSubscriber implements EventSubscriberInter
       return;
     }
 
+    // The listener is being run multiple times, but cannot be removed b/c
+    // it has to work with the bulk uploader as well.  This ensures that
+    // it only attempts to save the partial report once.
     $saved = &drupal_static(__FUNCTION__ . md5(join('.', $row->getSourceIdValues())), FALSE);
     if ($saved) {
       return;

--- a/docroot/modules/custom/foia_upload_xml/src/FoiaUploadXmlMigrateExecutable.php
+++ b/docroot/modules/custom/foia_upload_xml/src/FoiaUploadXmlMigrateExecutable.php
@@ -31,6 +31,10 @@ class FoiaUploadXmlMigrateExecutable extends MigrateExecutable {
       $isFailedAgencyMigration = $this->migration->id() === 'foia_agency_report' && $e->getStatus() == MigrateIdMapInterface::STATUS_FAILED;
       if ($isFailedAgencyMigration) {
         $this->getFailureHandler($e)->handle();
+        $this->migration->foiaErrorInformation = [
+          'status' => $e->getStatus(),
+          'row' => $this->migration->getSourcePlugin()->current(),
+        ];
       }
 
       throw $e;


### PR DESCRIPTION
* Adds information about the report that failed to be imported to the migration class.
* In the POST_IMPORT event, saves the data that has been processed to the node.
* After partially importing the report, sets the report node moderation state to draft.