### PR TITLE
FOIA-000: Add default status to component api.

### DIFF
--- a/config/default/jsonapi_extras.jsonapi_resource_config.node--agency_component.yml
+++ b/config/default/jsonapi_extras.jsonapi_resource_config.node--agency_component.yml
@@ -4,6 +4,12 @@ status: true
 dependencies:
   config:
     - node.type.agency_component
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    default_filter:
+      'filter:status': '1'
 id: node--agency_component
 disabled: false
 path: agency_components


### PR DESCRIPTION
* Adds a default status filter to the agency_component jsonapi endpoint, limiting
returned agency components to published nodes only.